### PR TITLE
Simplify device class names

### DIFF
--- a/src/nitrokey/nk3/__init__.py
+++ b/src/nitrokey/nk3/__init__.py
@@ -7,15 +7,15 @@
 
 from typing import List, Optional
 
-from nitrokey.trussed import DeviceData, NitrokeyTrussedBase
+from nitrokey.trussed import DeviceData, TrussedBase
 from nitrokey.trussed._bootloader.nrf52 import SignatureKey
 
-from ._bootloader import Nitrokey3Bootloader as Nitrokey3Bootloader  # noqa: F401
-from ._device import Nitrokey3Device as Nitrokey3Device  # noqa: F401
+from ._bootloader import NK3Bootloader as NK3Bootloader  # noqa: F401
+from ._device import NK3 as NK3  # noqa: F401
 
-_PID_NITROKEY3_DEVICE = 0x42B2
-_PID_NITROKEY3_LPC55_BOOTLOADER = 0x42DD
-_PID_NITROKEY3_NRF52_BOOTLOADER = 0x42E8
+_PID_NK3_DEVICE = 0x42B2
+_PID_NK3_LPC55_BOOTLOADER = 0x42DD
+_PID_NK3_NRF52_BOOTLOADER = 0x42E8
 
 NK3_DATA = DeviceData(
     name="Nitrokey 3",
@@ -36,16 +36,16 @@ NK3_DATA = DeviceData(
 )
 
 
-def list() -> List[NitrokeyTrussedBase]:
-    devices: List[NitrokeyTrussedBase] = []
-    devices.extend(Nitrokey3Bootloader.list())
-    devices.extend(Nitrokey3Device.list())
+def list() -> List[TrussedBase]:
+    devices: List[TrussedBase] = []
+    devices.extend(NK3Bootloader.list())
+    devices.extend(NK3.list())
     return devices
 
 
-def open(path: str) -> Optional[NitrokeyTrussedBase]:
-    device = Nitrokey3Device.open(path)
-    bootloader_device = Nitrokey3Bootloader.open(path)
+def open(path: str) -> Optional[TrussedBase]:
+    device = NK3.open(path)
+    bootloader_device = NK3Bootloader.open(path)
     if device and bootloader_device:
         raise Exception(f"Found multiple devices at path {path}")
     if device:

--- a/src/nitrokey/nk3/_bootloader.py
+++ b/src/nitrokey/nk3/_bootloader.py
@@ -8,75 +8,72 @@
 from typing import List, Optional, Sequence
 
 from nitrokey import _VID_NITROKEY
-from nitrokey.trussed._bootloader import NitrokeyTrussedBootloader
-from nitrokey.trussed._bootloader.lpc55 import NitrokeyTrussedBootloaderLpc55
-from nitrokey.trussed._bootloader.nrf52 import (
-    NitrokeyTrussedBootloaderNrf52,
-    SignatureKey,
-)
+from nitrokey.trussed._bootloader import TrussedBootloader
+from nitrokey.trussed._bootloader.lpc55 import TrussedBootloaderLpc55
+from nitrokey.trussed._bootloader.nrf52 import SignatureKey, TrussedBootloaderNrf52
 
 
-class Nitrokey3Bootloader(NitrokeyTrussedBootloader):
+class NK3Bootloader(TrussedBootloader):
     @staticmethod
-    def list() -> List["Nitrokey3Bootloader"]:
-        devices: List[Nitrokey3Bootloader] = []
-        devices.extend(Nitrokey3BootloaderLpc55._list())
-        devices.extend(Nitrokey3BootloaderNrf52._list())
+    def list() -> List["NK3Bootloader"]:
+        devices: List[NK3Bootloader] = []
+        devices.extend(NK3BootloaderLpc55._list())
+        devices.extend(NK3BootloaderNrf52._list())
         return devices
 
     @staticmethod
-    def open(path: str) -> Optional["Nitrokey3Bootloader"]:
-        lpc55 = Nitrokey3BootloaderLpc55._open(path)
+    def open(path: str) -> Optional["NK3Bootloader"]:
+        lpc55 = NK3BootloaderLpc55._open(path)
         if lpc55:
             return lpc55
 
-        nrf52 = Nitrokey3BootloaderNrf52._open(path)
+        nrf52 = NK3BootloaderNrf52._open(path)
         if nrf52:
             return nrf52
 
         return None
 
 
-class Nitrokey3BootloaderLpc55(NitrokeyTrussedBootloaderLpc55, Nitrokey3Bootloader):
+class NK3BootloaderLpc55(TrussedBootloaderLpc55, NK3Bootloader):
     @property
     def name(self) -> str:
         return "Nitrokey 3 Bootloader (LPC55)"
 
     @property
     def pid(self) -> int:
-        from . import _PID_NITROKEY3_LPC55_BOOTLOADER
+        from . import _PID_NK3_LPC55_BOOTLOADER
 
-        return _PID_NITROKEY3_LPC55_BOOTLOADER
+        return _PID_NK3_LPC55_BOOTLOADER
 
     @classmethod
-    def _list(cls) -> List["Nitrokey3BootloaderLpc55"]:
-        from . import _PID_NITROKEY3_LPC55_BOOTLOADER
+    def _list(cls) -> List["NK3BootloaderLpc55"]:
+        from . import _PID_NK3_LPC55_BOOTLOADER
 
-        return cls.list_vid_pid(_VID_NITROKEY, _PID_NITROKEY3_LPC55_BOOTLOADER)
+        return cls.list_vid_pid(_VID_NITROKEY, _PID_NK3_LPC55_BOOTLOADER)
 
 
-class Nitrokey3BootloaderNrf52(NitrokeyTrussedBootloaderNrf52, Nitrokey3Bootloader):
+class NK3BootloaderNrf52(TrussedBootloaderNrf52, NK3Bootloader):
     @property
     def name(self) -> str:
         return "Nitrokey 3 Bootloader (NRF52)"
 
     @property
     def pid(self) -> int:
-        from . import _PID_NITROKEY3_NRF52_BOOTLOADER
+        from . import _PID_NK3_NRF52_BOOTLOADER
 
-        return _PID_NITROKEY3_NRF52_BOOTLOADER
-
-    @classmethod
-    def _list(cls) -> List["Nitrokey3BootloaderNrf52"]:
-        from . import _PID_NITROKEY3_NRF52_BOOTLOADER
-
-        return cls.list_vid_pid(_VID_NITROKEY, _PID_NITROKEY3_NRF52_BOOTLOADER)
+        return _PID_NK3_NRF52_BOOTLOADER
 
     @classmethod
-    def _open(cls, path: str) -> Optional["Nitrokey3BootloaderNrf52"]:
-        from . import _PID_NITROKEY3_NRF52_BOOTLOADER
+    def _list(cls) -> List["NK3BootloaderNrf52"]:
+        from . import _PID_NK3_NRF52_BOOTLOADER
 
-        return cls.open_vid_pid(_VID_NITROKEY, _PID_NITROKEY3_NRF52_BOOTLOADER, path)
+        return cls.list_vid_pid(_VID_NITROKEY, _PID_NK3_NRF52_BOOTLOADER)
+
+    @classmethod
+    def _open(cls, path: str) -> Optional["NK3BootloaderNrf52"]:
+        from . import _PID_NK3_NRF52_BOOTLOADER
+
+        return cls.open_vid_pid(_VID_NITROKEY, _PID_NK3_NRF52_BOOTLOADER, path)
 
     @property
     def signature_keys(self) -> Sequence[SignatureKey]:

--- a/src/nitrokey/nk3/_device.py
+++ b/src/nitrokey/nk3/_device.py
@@ -7,7 +7,7 @@
 
 from fido2.hid import CtapHidDevice
 
-from nitrokey.trussed import Fido2Certs, NitrokeyTrussedDevice, Version
+from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
 
 FIDO2_CERTS = [
     Fido2Certs(
@@ -27,7 +27,7 @@ FIDO2_CERTS = [
 ]
 
 
-class Nitrokey3Device(NitrokeyTrussedDevice):
+class NK3(TrussedDevice):
     """A Nitrokey 3 device running the firmware."""
 
     def __init__(self, device: CtapHidDevice) -> None:
@@ -35,14 +35,14 @@ class Nitrokey3Device(NitrokeyTrussedDevice):
 
     @property
     def pid(self) -> int:
-        from . import _PID_NITROKEY3_DEVICE
+        from . import _PID_NK3_DEVICE
 
-        return _PID_NITROKEY3_DEVICE
+        return _PID_NK3_DEVICE
 
     @property
     def name(self) -> str:
         return "Nitrokey 3"
 
     @classmethod
-    def from_device(cls, device: CtapHidDevice) -> "Nitrokey3Device":
+    def from_device(cls, device: CtapHidDevice) -> "NK3":
         return cls(device)

--- a/src/nitrokey/nk3/secrets_app.py
+++ b/src/nitrokey/nk3/secrets_app.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 import tlv8
 from semver.version import Version
 
-from nitrokey.nk3 import Nitrokey3Device
+from nitrokey.nk3 import NK3
 from nitrokey.trussed import App
 
 LogFn = Callable[[str], Any]
@@ -303,12 +303,12 @@ class SecretsApp:
 
     log: logging.Logger
     logfn: LogFn
-    dev: Nitrokey3Device
+    dev: NK3
     write_corpus_fn: Optional[WriteCorpusFn]
     _cache_status: Optional[SelectResponse]
     _metadata: dict[Any, Any]
 
-    def __init__(self, dev: Nitrokey3Device, logfn: Optional[LogFn] = None):
+    def __init__(self, dev: NK3, logfn: Optional[LogFn] = None):
         self._cache_status = None
         self.write_corpus_fn = None
         self.log = logging.getLogger("otpapp")

--- a/src/nitrokey/nkpk.py
+++ b/src/nitrokey/nkpk.py
@@ -10,20 +10,11 @@ from typing import List, Optional, Sequence
 from fido2.hid import CtapHidDevice
 
 from nitrokey import _VID_NITROKEY
-from nitrokey.trussed import (
-    DeviceData,
-    Fido2Certs,
-    NitrokeyTrussedBase,
-    NitrokeyTrussedDevice,
-    Version,
-)
-from nitrokey.trussed._bootloader.nrf52 import (
-    NitrokeyTrussedBootloaderNrf52,
-    SignatureKey,
-)
+from nitrokey.trussed import DeviceData, Fido2Certs, TrussedBase, TrussedDevice, Version
+from nitrokey.trussed._bootloader.nrf52 import SignatureKey, TrussedBootloaderNrf52
 
-_PID_NITROKEY_PASSKEY_DEVICE = 0x42F3
-_PID_NITROKEY_PASSKEY_BOOTLOADER = 0x42F4
+_PID_NKPK_DEVICE = 0x42F3
+_PID_NKPK_BOOTLOADER = 0x42F4
 
 _FIDO2_CERTS = [
     Fido2Certs(
@@ -53,55 +44,55 @@ NKPK_DATA = DeviceData(
 )
 
 
-class NitrokeyPasskeyDevice(NitrokeyTrussedDevice):
+class NKPK(TrussedDevice):
     def __init__(self, device: CtapHidDevice) -> None:
         super().__init__(device, _FIDO2_CERTS)
 
     @property
     def pid(self) -> int:
-        return _PID_NITROKEY_PASSKEY_DEVICE
+        return _PID_NKPK_DEVICE
 
     @property
     def name(self) -> str:
         return "Nitrokey Passkey"
 
     @classmethod
-    def from_device(cls, device: CtapHidDevice) -> "NitrokeyPasskeyDevice":
+    def from_device(cls, device: CtapHidDevice) -> "NKPK":
         return cls(device)
 
 
-class NitrokeyPasskeyBootloader(NitrokeyTrussedBootloaderNrf52):
+class NKPKBootloader(TrussedBootloaderNrf52):
     @property
     def name(self) -> str:
         return "Nitrokey Passkey Bootloader"
 
     @property
     def pid(self) -> int:
-        return _PID_NITROKEY_PASSKEY_BOOTLOADER
+        return _PID_NKPK_BOOTLOADER
 
     @classmethod
-    def list(cls) -> List["NitrokeyPasskeyBootloader"]:
-        return cls.list_vid_pid(_VID_NITROKEY, _PID_NITROKEY_PASSKEY_BOOTLOADER)
+    def list(cls) -> List["NKPKBootloader"]:
+        return cls.list_vid_pid(_VID_NITROKEY, _PID_NKPK_BOOTLOADER)
 
     @classmethod
-    def open(cls, path: str) -> Optional["NitrokeyPasskeyBootloader"]:
-        return cls.open_vid_pid(_VID_NITROKEY, _PID_NITROKEY_PASSKEY_BOOTLOADER, path)
+    def open(cls, path: str) -> Optional["NKPKBootloader"]:
+        return cls.open_vid_pid(_VID_NITROKEY, _PID_NKPK_BOOTLOADER, path)
 
     @property
     def signature_keys(self) -> Sequence[SignatureKey]:
         return NKPK_DATA.nrf52_signature_keys
 
 
-def list() -> List[NitrokeyTrussedBase]:
-    devices: List[NitrokeyTrussedBase] = []
-    devices.extend(NitrokeyPasskeyBootloader.list())
-    devices.extend(NitrokeyPasskeyDevice.list())
+def list() -> List[TrussedBase]:
+    devices: List[TrussedBase] = []
+    devices.extend(NKPKBootloader.list())
+    devices.extend(NKPK.list())
     return devices
 
 
-def open(path: str) -> Optional[NitrokeyTrussedBase]:
-    device = NitrokeyPasskeyDevice.open(path)
-    bootloader_device = NitrokeyPasskeyBootloader.open(path)
+def open(path: str) -> Optional[TrussedBase]:
+    device = NKPK.open(path)
+    bootloader_device = NKPKBootloader.open(path)
     if device and bootloader_device:
         raise Exception(f"Found multiple devices at path {path}")
     if device:

--- a/src/nitrokey/trussed/__init__.py
+++ b/src/nitrokey/trussed/__init__.py
@@ -12,21 +12,17 @@ from typing import TYPE_CHECKING
 
 from nitrokey.updates import Repository
 
-from ._base import NitrokeyTrussedBase as NitrokeyTrussedBase  # noqa: F401
+from ._base import TrussedBase as TrussedBase  # noqa: F401
 from ._bootloader import Device as Device  # noqa: F401
 from ._bootloader import FirmwareContainer as FirmwareContainer  # noqa: F401
 from ._bootloader import FirmwareMetadata as FirmwareMetadata  # noqa: F401
-from ._bootloader import (  # noqa: F401
-    NitrokeyTrussedBootloader as NitrokeyTrussedBootloader,
-)
+from ._bootloader import TrussedBootloader as TrussedBootloader  # noqa: F401
 from ._bootloader import Variant as Variant  # noqa: F401
 from ._bootloader import parse_firmware_image as parse_firmware_image  # noqa: F401
 from ._device import App as App  # noqa: F401
-from ._device import NitrokeyTrussedDevice as NitrokeyTrussedDevice  # noqa: F401
-from ._exceptions import (  # noqa: F401
-    NitrokeyTrussedException as NitrokeyTrussedException,
-)
+from ._device import TrussedDevice as TrussedDevice  # noqa: F401
 from ._exceptions import TimeoutException as TimeoutException  # noqa: F401
+from ._exceptions import TrussedException as TrussedException  # noqa: F401
 from ._utils import Fido2Certs as Fido2Certs  # noqa: F401
 from ._utils import Uuid as Uuid  # noqa: F401
 from ._utils import Version as Version  # noqa: F401

--- a/src/nitrokey/trussed/_base.py
+++ b/src/nitrokey/trussed/_base.py
@@ -12,10 +12,10 @@ from nitrokey import _VID_NITROKEY
 
 from ._utils import Uuid
 
-T = TypeVar("T", bound="NitrokeyTrussedBase")
+T = TypeVar("T", bound="TrussedBase")
 
 
-class NitrokeyTrussedBase(ABC):
+class TrussedBase(ABC):
     """
     Base class for Nitrokey devices using the Trussed framework and running
     the firmware or the bootloader.

--- a/src/nitrokey/trussed/_bootloader/__init__.py
+++ b/src/nitrokey/trussed/_bootloader/__init__.py
@@ -17,7 +17,7 @@ from re import Pattern
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union
 from zipfile import ZipFile
 
-from .._base import NitrokeyTrussedBase
+from .._base import TrussedBase
 from .._utils import Version
 
 if TYPE_CHECKING:
@@ -109,7 +109,7 @@ class FirmwareMetadata:
     signed_by_nitrokey: bool = False
 
 
-class NitrokeyTrussedBootloader(NitrokeyTrussedBase):
+class TrussedBootloader(TrussedBase):
     @abstractmethod
     def update(
         self,

--- a/src/nitrokey/trussed/_bootloader/lpc55.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55.py
@@ -20,19 +20,19 @@ from spsdk.utils.usbfilter import USBDeviceFilter
 
 from nitrokey.trussed import Uuid, Version
 
-from . import FirmwareMetadata, NitrokeyTrussedBootloader, ProgressCallback, Variant
+from . import FirmwareMetadata, ProgressCallback, TrussedBootloader, Variant
 
 RKTH = bytes.fromhex("050aad3e77791a81e59c5b2ba5a158937e9460ee325d8ccba09734b8fdebb171")
 KEK = bytes([0xAA] * 32)
 UUID_LEN = 4
 FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-lpc55-(?P<version>.*)\\.sb2$")
 
-T = TypeVar("T", bound="NitrokeyTrussedBootloaderLpc55")
+T = TypeVar("T", bound="TrussedBootloaderLpc55")
 
 logger = logging.getLogger(__name__)
 
 
-class NitrokeyTrussedBootloaderLpc55(NitrokeyTrussedBootloader):
+class TrussedBootloaderLpc55(TrussedBootloader):
     """A Nitrokey 3 device running the LPC55 bootloader."""
 
     def __init__(self, device: UsbDevice):

--- a/src/nitrokey/trussed/_bootloader/nrf52.py
+++ b/src/nitrokey/trussed/_bootloader/nrf52.py
@@ -21,7 +21,7 @@ from ecdsa.keys import BadSignatureError
 
 from nitrokey.trussed import Uuid, Version
 
-from . import FirmwareMetadata, NitrokeyTrussedBootloader, ProgressCallback, Variant
+from . import FirmwareMetadata, ProgressCallback, TrussedBootloader, Variant
 from .nrf52_upload.dfu.dfu_transport import DfuEvent
 from .nrf52_upload.dfu.dfu_transport_serial import DfuTransportSerial
 from .nrf52_upload.dfu.init_packet_pb import InitPacketPB
@@ -35,7 +35,7 @@ FILENAME_PATTERN = re.compile(
     "(firmware|alpha)-(nk3..|nkpk)-nrf52-(?P<version>.*)\\.zip$"
 )
 
-T = TypeVar("T", bound="NitrokeyTrussedBootloaderNrf52")
+T = TypeVar("T", bound="TrussedBootloaderNrf52")
 
 
 @dataclass
@@ -119,7 +119,7 @@ class Image:
         return image
 
 
-class NitrokeyTrussedBootloaderNrf52(NitrokeyTrussedBootloader):
+class TrussedBootloaderNrf52(TrussedBootloader):
     def __init__(self, path: str, uuid: int) -> None:
         self._path = path
         self._uuid = uuid

--- a/src/nitrokey/trussed/_device.py
+++ b/src/nitrokey/trussed/_device.py
@@ -15,10 +15,10 @@ from typing import Optional, Sequence, TypeVar, Union
 
 from fido2.hid import CtapHidDevice, open_device
 
-from ._base import NitrokeyTrussedBase
+from ._base import TrussedBase
 from ._utils import Fido2Certs, Uuid
 
-T = TypeVar("T", bound="NitrokeyTrussedDevice")
+T = TypeVar("T", bound="TrussedDevice")
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class App(Enum):
     ADMIN = 0x72
 
 
-class NitrokeyTrussedDevice(NitrokeyTrussedBase):
+class TrussedDevice(TrussedBase):
     def __init__(
         self, device: CtapHidDevice, fido2_certs: Sequence[Fido2Certs]
     ) -> None:

--- a/src/nitrokey/trussed/_exceptions.py
+++ b/src/nitrokey/trussed/_exceptions.py
@@ -6,10 +6,10 @@
 # copied, modified, or distributed except according to those terms.
 
 
-class NitrokeyTrussedException(Exception):
+class TrussedException(Exception):
     pass
 
 
-class TimeoutException(NitrokeyTrussedException):
+class TimeoutException(TrussedException):
     def __init__(self) -> None:
         super().__init__("The user confirmation request timed out")

--- a/src/nitrokey/trussed/admin_app.py
+++ b/src/nitrokey/trussed/admin_app.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fido2 import cbor
 from fido2.ctap import CtapError
 
-from . import App, NitrokeyTrussedDevice, TimeoutException, Uuid, Version
+from . import App, TimeoutException, TrussedDevice, Uuid, Version
 
 RNG_LEN = 57
 UUID_LEN = 16
@@ -149,7 +149,7 @@ class ConfigStatus(Enum):
 
 
 class AdminApp:
-    def __init__(self, device: NitrokeyTrussedDevice) -> None:
+    def __init__(self, device: TrussedDevice) -> None:
         self.device = device
 
     def _call(

--- a/src/nitrokey/trussed/provisioner_app.py
+++ b/src/nitrokey/trussed/provisioner_app.py
@@ -2,7 +2,7 @@ import enum
 from enum import Enum
 from typing import Optional
 
-from nitrokey.trussed import App, NitrokeyTrussedDevice
+from nitrokey.trussed import App, TrussedDevice
 
 
 @enum.unique
@@ -20,7 +20,7 @@ class ProvisionerCommand(Enum):
 
 
 class ProvisionerApp:
-    def __init__(self, device: NitrokeyTrussedDevice) -> None:
+    def __init__(self, device: TrussedDevice) -> None:
         self.device = device
 
         try:


### PR DESCRIPTION
This patch renames the device classes to shorter but still unique names, for example Nitrokey3Device to NK3 or Nitrokey3Bootloader to NK3Bootloader.  This makes code using the SDK less verbose and easier to read.

Fixes: https://github.com/Nitrokey/nitrokey-sdk-py/issues/18