### PR TITLE
ci: Fix indentation of publish job

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -53,25 +53,25 @@ jobs:
         with:
           name: nitrokey-pypi
           path: dist
-publish-binary:
-  name: Publish
-  runs-on: ubuntu-latest
-  container: python:3.9-slim
-  needs: build
-  env:
-    POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-    POETRY_PYPI_URL: https://upload.pypi.org/legacy/
-  steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Download artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: nitrokey-pypi
-        path: dist
-    - name: Install Poetry
-      run: pip install poetry
-    - name: Configure PyPI repository
-      run: poetry config repositories.pypi $POETRY_PYPI_URL
-    - name: Publish release
-      run: poetry publish --repository pypi
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    container: python:3.9-slim
+    needs: build
+    env:
+      POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      POETRY_PYPI_URL: https://upload.pypi.org/legacy/
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nitrokey-pypi
+          path: dist
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Configure PyPI repository
+        run: poetry config repositories.pypi $POETRY_PYPI_URL
+      - name: Publish release
+        run: poetry publish --repository pypi


### PR DESCRIPTION
While at it, rename publish-binary to publish because we’re also publishing source code.