### PR TITLE
ci: Use PyPI environment for publish job

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.9-slim
     needs: build
+    environment: PyPI
     env:
       POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       POETRY_PYPI_URL: https://upload.pypi.org/legacy/


### PR DESCRIPTION
Using environments allows to configure additional protections for the secret, e. g. manual approval of the publish workflow.