### PR TITLE
And random generator and config failures to init status bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--
+### Features
+
+- `trussed.admin_app`: Add error codes `CONFIG_ERROR` and `RNG_ERROR` to `InitStatus` enum
 
 ## [v0.1.0](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.1.0) (2024-07-29)
 

--- a/src/nitrokey/trussed/admin_app.py
+++ b/src/nitrokey/trussed/admin_app.py
@@ -60,6 +60,8 @@ class InitStatus(IntFlag):
     EXTERNAL_FLASH_ERROR = 0b0100
     MIGRATION_ERROR = 0b1000
     SE050_ERROR = 0b00010000
+    CONFIG_ERROR = 0b00100000
+    RNG_ERROR = 0b01000000
 
     def is_error(self) -> bool:
         return self.value != 0


### PR DESCRIPTION
"frontport" of https://github.com/Nitrokey/pynitrokey/pull/556