### PR TITLE
Test installation with pip on all supported systems

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,19 +114,22 @@ jobs:
         run: make test
   test-pip:
     name: Run test suite with pip installation
-    runs-on: ubuntu-latest
-    container: python:3.9-slim
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install required packages
-        run: apt update && apt install -y ${REQUIRED_PACKAGES}
-      - name: Create virtual environment
-        run: python3 -m venv venv
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install SDK
-        run: ./venv/bin/pip install .
+        run: pip install .
       - name: Run test suite
-        run: ./venv/bin/python -m unittest -v
+        run: python -m unittest -v
   test-readme:
     name: Run example code from readme
     runs-on: ubuntu-latest

--- a/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/unix/unix_lister.py
+++ b/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/unix/unix_lister.py
@@ -37,12 +37,11 @@
 
 import sys
 
+from ..enumerated_device import EnumeratedDevice
 from ..lister_backend import AbstractLister
 
 if "linux" in sys.platform or sys.platform == "darwin":
     import serial.tools.list_ports
-
-    from ..enumerated_device import EnumeratedDevice
 
 
 def create_id_string(sno: str, PID: str, VID: str) -> str:


### PR DESCRIPTION
This PR extends the job running the test suite for an pip installation to run on all supported platforms and with all supported Python versions.

The new CI configuration exposes a missing import in the `nrf52_upload` module on Windows that is also fixed by the PR.