### PR TITLE
ci: Remove full compatibility tests from default workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -125,7 +124,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
       - name: Install SDK
         run: pip install .
       - name: Run test suite

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -1,0 +1,26 @@
+name: Full compatibility tests
+on:
+  schedule:
+    # run daily
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  test-pip:
+    name: Run test suite with pip installation
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install SDK
+        run: pip install .
+      - name: Run test suite
+        run: python -m unittest -v


### PR DESCRIPTION
The full compatibility tests with all Python versions on all operating systems lead to a significant slowdown when multiple workflows are running.  With this patch, we only run tests with Python 3.9 on the three operating systems.  The full tests are run once a day or after a manual trigger (e. g. before a release).