### PR TITLE
Remove two step update handling on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove `ecdsa` dependency
+- Remove two step update handling on macOS
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.2...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `ecdsa` dependency
 - Remove two step update handling on macOS
+- Correct update message
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.2...HEAD)
 

--- a/src/nitrokey/nk3/updates.py
+++ b/src/nitrokey/nk3/updates.py
@@ -9,6 +9,7 @@ import enum
 import logging
 import platform
 import time
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from io import BytesIO
@@ -119,9 +120,11 @@ class UpdateUi(ABC):
     def confirm_update_same_version(self, version: Version) -> None:
         pass
 
-    @abstractmethod
     def request_repeated_update(self) -> Optional[Exception]:
-        pass
+        warnings.warn(
+            "UpdateUi.request_repeated_update is no longer needed", DeprecationWarning
+        )
+        return None
 
     @abstractmethod
     def pre_bootloader_hint(self) -> None:
@@ -323,13 +326,6 @@ class Updater:
 
             # needed for udev to properly handle new device
             time.sleep(1)
-
-            maybe_exc = self.ui.request_repeated_update()
-            if platform.system() == "Darwin" and maybe_exc is not None:
-                # Currently there is an issue with device enumeration after reboot on macOS, see
-                # <https://github.com/Nitrokey/pynitrokey/issues/145>.  To avoid this issue, we
-                # cancel the command now and ask the user to run it again.
-                raise maybe_exc
 
             self.ui.pre_bootloader_hint()
 

--- a/src/nitrokey/nk3/updates.py
+++ b/src/nitrokey/nk3/updates.py
@@ -65,7 +65,7 @@ def get_extra_information(upath: UpdatePath) -> List[str]:
             "",
             "During this update process the internal filesystem will be migrated!",
             "- Migration will only work, if your internal filesystem does not contain more than 45 Resident Keys. If you have more please remove some.",
-            "- After the update it might take up to 3minutes for the first boot.",
+            "- After the update it might take up to 3 minutes for the first boot.",
             "Never unplug the device while the LED is active!",
         ]
     return out


### PR DESCRIPTION
This PR removes the two step update handling on macOS, which required to invoke the update command twice.
Additionally it corrects a typo in an update message.