### PR TITLE
Update RPM build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install required packages
-        run: dnf makecache && dnf install -y make rpm-build python python-pip
+        run: dnf makecache && dnf install -y make rpm-build python python-pip python3-devel gcc systemd-devel
       - name: Install Poetry
         run: pip install poetry
       - name: Create virtual environment

--- a/ci-scripts/linux/rpm/protobuf.patch
+++ b/ci-scripts/linux/rpm/protobuf.patch
@@ -1,11 +1,21 @@
+diff --git a/poetry.lock b/poetry.lock
+index 6038989..babcefb 100644
+--- a/poetry.lock
++++ b/poetry.lock
+@@ -1485,4 +1485,4 @@ type = ["pytest-mypy"]
+ [metadata]
+ lock-version = "2.0"
+ python-versions = "^3.9"
+-content-hash = "bf3cf1d5036f82de8a351d2da4aba6c8b2bf85fd6bd75e7b12502e0cca0057d2"
++content-hash = "141c56959904ac2d8688a01afa5350137365bbefce5e86c62fd77b37430b3520"
 diff --git a/pyproject.toml b/pyproject.toml
-index acdfc95..1b8558f 100644
+index 99746df..9922246 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -31,7 +31,7 @@ hidapi = "^0.14"
+@@ -30,7 +30,7 @@ crcmod = "^1.7"
+ hidapi = "^0.14"
  
  # nrf52
- ecdsa = ">=0.18"
 -protobuf = "^5.26"
 +protobuf = ">=3.19"
  pyserial = "^3.5"

--- a/ci-scripts/linux/rpm/python3-nitrokey.spec
+++ b/ci-scripts/linux/rpm/python3-nitrokey.spec
@@ -15,6 +15,7 @@ BuildRequires:  %{py3_dist crcmod}
 BuildRequires:  %{py3_dist cryptography}
 BuildRequires:  %{py3_dist fido2}
 BuildRequires:  %{py3_dist hidapi}
+BuildRequires:  %{py3_dist poetry-core}
 BuildRequires:  %{py3_dist protobuf}
 BuildRequires:  %{py3_dist pyserial}
 BuildRequires:  %{py3_dist semver}
@@ -44,5 +45,7 @@ The Nitrokey Python SDK can be used to use and configure Nitrokey devices.
 %doc README.md
 
 %changelog
+* Fri Nov 01 2024 Markus Merklinger <markus@nitrokey.com> - 0.2.3-1
+- Add build dependency.
 * Mon Oct 21 2024 Markus Merklinger <markus@nitrokey.com> - 0.2.0-1
 - Initial package.


### PR DESCRIPTION
This PR updates the RPM build in preparation for the next release.

Detailed changes:
- Update `protobuf.patch`, due to changes in `pyproject.tom`. Also now takes the changes in `poetry.lock` into account.
- Add a new build dependency which is required if the Poetry build backend should be used.
- Add more dependencies to RPM version accordance check in CI pipeline. Change due to new released Fedora version.