### PR TITLE
Use trusted publishing for PyPI

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -1,52 +1,40 @@
 name: Continuous delivery - PyPI
 
 on:
+  push:
+  pull_request:
   release:
     types: [released]
 
 env:
-  REQUIRED_PACKAGES: make
   POETRY_SPEC: poetry >=1,<2
 
 jobs:
-  version-check:
-    name: Check versioning
+  check-package-version:
+    name: Check package version
     runs-on: ubuntu-latest
     container: python:3.9-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install required packages
-        run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
-      - name: Create virtual environment
-        run: make install
-      - name: Check version tag format
+      - name: Check package version format
         shell: bash
         run: |
-          VERSION_TAG="${{ github.event.release.tag_name }}"
-          if [[ $VERSION_TAG =~ ^v[0-9]+.[0-9]+.[0-9]+(-rc\.[1-9])?$ ]]; then exit 0; else exit 1; fi
-      - name: Check if version tag and package version are equal
-        shell: bash
-        run: |
-          VERSION_TAG="${{ github.event.release.tag_name }}"
-          PACKAGE_VERSION="v"$(poetry version --short)
-          if [ $VERSION_TAG == $PACKAGE_VERSION ]; then exit 0; else exit 1; fi
+          PACKAGE_VERSION=$(poetry version --short)
+          echo "PACKAGE_VERSION = $PACKAGE_VERSION"
+          if [[ $PACKAGE_VERSION =~ ^[0-9]+.[0-9]+.[0-9]+(-rc\.[1-9])?$ ]]; then exit 0; else exit 1; fi
   build:
     name: Build
     runs-on: ubuntu-latest
     container: python:3.9-slim
-    needs: version-check
+    needs: check-package-version
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install required packages
-        run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
-      - name: Create virtual environment
-        run: make install
       - name: Build
         run: poetry build
       - name: Upload artifacts
@@ -54,15 +42,16 @@ jobs:
         with:
           name: nitrokey-pypi
           path: dist
-  publish:
-    name: Publish
+  publish-testpypi:
+    name: Publish to TestPyPI
     runs-on: ubuntu-latest
-    container: python:3.9-slim
     needs: build
-    environment: PyPI
-    env:
-      POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-      POETRY_PYPI_URL: https://upload.pypi.org/legacy/
+    if: github.event.name == 'release' || github.ref == 'refs/heads/main'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/nitrokey
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -71,9 +60,46 @@ jobs:
         with:
           name: nitrokey-pypi
           path: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+  check-tag-version:
+    name: Check tag version
+    runs-on: ubuntu-latest
+    container: python:3.9-slim
+    if: github.event.name == 'release'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
-      - name: Configure PyPI repository
-        run: poetry config repositories.pypi $POETRY_PYPI_URL
-      - name: Publish release
-        run: poetry publish --repository pypi
+      - name: Check tag version
+        shell: bash
+        run: |
+          VERSION_TAG="${{ github.event.release.tag_name }}"
+          PACKAGE_VERSION="v"$(poetry version --short)
+          echo "VERSION_TAG = $VERSION_TAG"
+          echo "PACKAGE_VERSION = $PACKAGE_VERSION"
+          if [ $VERSION_TAG == $PACKAGE_VERSION ]; then exit 0; else exit 1; fi
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build, check-tag-version]
+    if: github.event.name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nitrokey
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nitrokey-pypi
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The list methods of `NK3` and `NKPK` now only open the respective device, based on the USB vendor and product ID.
+- Use trusted publishing for PyPI.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.3...HEAD)
 


### PR DESCRIPTION
This patch changes the CD workflow to use trusted publishing to PyPI. The main changes are:

- The CD workflow is always executed and always publishes to TestPyPI.
- For releases, the workflow also publishes to PyPI.
- Instead of using access tokens, we use a GitHub environment for the publication jobs.  This environment is configured on TestPyPI/PyPI and release jobs running in that environment can publish releases.


---

TestPyPI works, PyPI still needs to be configured and tested.