### PR TITLE
Open only CtapHid device for the respective Nitrokey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- The list methods of `NK3` and `NKPK` now only open the respective device, based on the USB vendor and product ID.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.3...HEAD)
 

--- a/src/nitrokey/nk3/_device.py
+++ b/src/nitrokey/nk3/_device.py
@@ -5,8 +5,11 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from fido2.hid import CtapHidDevice
+from typing import List
 
+from fido2.hid import CtapHidDevice, list_descriptors, open_device
+
+from nitrokey import _VID_NITROKEY
 from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
 
 FIDO2_CERTS = [
@@ -46,3 +49,20 @@ class NK3(TrussedDevice):
     @classmethod
     def from_device(cls, device: CtapHidDevice) -> "NK3":
         return cls(device)
+
+    @classmethod
+    def list(cls) -> List["NK3"]:
+        from . import _PID_NK3_DEVICE
+
+        descriptors = [
+            desc
+            for desc in list_descriptors()  # type: ignore
+            if desc.vid == _VID_NITROKEY and desc.pid == _PID_NK3_DEVICE
+        ]
+
+        devices = []
+
+        # iterate on all descriptors found and open the device
+        for desc in descriptors:
+            devices.append(cls.from_device(open_device(desc.path)))
+        return devices

--- a/src/nitrokey/nkpk.py
+++ b/src/nitrokey/nkpk.py
@@ -7,7 +7,7 @@
 
 from typing import List, Optional, Sequence, Union
 
-from fido2.hid import CtapHidDevice
+from fido2.hid import CtapHidDevice, list_descriptors, open_device
 
 from nitrokey import _VID_NITROKEY
 from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
@@ -59,6 +59,21 @@ class NKPK(TrussedDevice):
     @classmethod
     def from_device(cls, device: CtapHidDevice) -> "NKPK":
         return cls(device)
+
+    @classmethod
+    def list(cls) -> List["NKPK"]:
+        descriptors = [
+            desc
+            for desc in list_descriptors()  # type: ignore
+            if desc.vid == _VID_NITROKEY and desc.pid == _PID_NKPK_DEVICE
+        ]
+
+        devices = []
+
+        # iterate on all descriptors found and open the device
+        for desc in descriptors:
+            devices.append(cls.from_device(open_device(desc.path)))
+        return devices
 
 
 class NKPKBootloader(TrussedBootloaderNrf52):

--- a/src/nitrokey/trussed/_device.py
+++ b/src/nitrokey/trussed/_device.py
@@ -11,7 +11,7 @@ import platform
 import sys
 from abc import abstractmethod
 from enum import Enum
-from typing import Optional, Sequence, TypeVar, Union
+from typing import List, Optional, Sequence, TypeVar, Union
 
 from fido2.hid import CtapHidDevice, open_device
 
@@ -110,15 +110,8 @@ class TrussedDevice(TrussedBase):
             return None
 
     @classmethod
-    def list(cls: type[T]) -> list[T]:
-        devices = []
-        for device in CtapHidDevice.list_devices():
-            try:
-                devices.append(cls.from_device(device))
-            except ValueError:
-                # not the correct device type, skip
-                pass
-        return devices
+    @abstractmethod
+    def list(cls: type[T]) -> List[T]: ...
 
 
 def _device_path_to_str(path: Union[bytes, str]) -> str:


### PR DESCRIPTION
This PR fixes the "wrong channel" error when accessing different device models after listing them.

Detailed changes:
- Changes `list` method on `TrussedDevice` to abstract.
- Implement `list` on `NK3` and `NKPK`.
- Uses the same mechanic for the device listing as the implementations for the bootloader devices.

Partly fixes #31