### PR TITLE
Release v0.2.4-rc.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Check versions (Python package and RPM specification)
         shell: bash
         run: |
-          PACKAGE_VERSION=$(poetry version --short)
+          PACKAGE_VERSION=$(poetry version --short | sed s'/-rc\./~rc/')
           RPM_VERSION=$(rpmspec -q --qf "%{version}" ci-scripts/linux/rpm/python3-nitrokey.spec)
           if [ $PACKAGE_VERSION == $RPM_VERSION ]; then exit 0; else exit 1; fi
   build-docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
+-
+
+[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4-rc.1...HEAD)
+
+## [v0.2.4-rc.1](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.2.4-rc.1) (2025-01-17)
+
 - The list methods of `NK3` and `NKPK` now only open the respective device, based on the USB vendor and product ID.
 - Use trusted publishing for PyPI.
 
-[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.3...HEAD)
+[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.3...v0.2.4-rc.1)
 
 ## [v0.2.3](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.2.3) (2024-11-02)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FORMAT_DIRS := src stubs tests
 LINT_DIRS := src tests
-PACKAGE_VERSION:=$(shell poetry version --short)
+PACKAGE_VERSION := $(shell poetry version --short)
 
 .PHONY: install
 install:
@@ -63,5 +63,6 @@ build-docs:
 	poetry run sphinx-build --fail-on-warning docs _build
 
 .PHONY: update-version
+update-version: RPM_VERSION=$(shell echo ${PACKAGE_VERSION} | sed 's/-rc\./~rc/')
 update-version:
-	sed -i "/^Version:/s/[[:digit:]].*/$(PACKAGE_VERSION)/" ci-scripts/linux/rpm/python3-nitrokey.spec
+	sed -i "/^Version:/s/[[:digit:]].*/$(RPM_VERSION)/" ci-scripts/linux/rpm/python3-nitrokey.spec

--- a/ci-scripts/linux/rpm/python3-nitrokey.spec
+++ b/ci-scripts/linux/rpm/python3-nitrokey.spec
@@ -1,5 +1,5 @@
 Name:           python3-nitrokey
-Version:        0.2.3
+Version:        0.2.4-rc.1
 Release:        %autorelease
 Summary:        Python SDK for Nitrokey devices
 

--- a/ci-scripts/linux/rpm/python3-nitrokey.spec
+++ b/ci-scripts/linux/rpm/python3-nitrokey.spec
@@ -1,5 +1,5 @@
 Name:           python3-nitrokey
-Version:        0.2.4-rc.1
+Version:        0.2.4~rc1
 Release:        %autorelease
 Summary:        Python SDK for Nitrokey devices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nitrokey"
-version = "0.2.3"
+version = "0.2.4-rc.1"
 description = "Nitrokey Python SDK"
 authors = ["Nitrokey <pypi@nitrokey.com>"]
 license = "Apache-2.0 or MIT"


### PR DESCRIPTION
This release candidate fixes concurrent access to different models and tests trusted publishing to PyPI.