### PR TITLE
Add support for a minimum SDK version for firmware updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Reboot devices in firmware mode before the update to make sure that the status is up to date.
   - Add `Warning` enum, `show_warning` and `raise_warning` methods to `UpdateUi` and `ignore_warnings` argument to `UpdateUi.__init__`.
 - Add support for updates to Nitrokey 3 firmware v1.8.2.
+- Add support for setting a minimum SDK version in firmware update containers.
+  - Add an `sdk` field to `nitrokey.trussed.FirmwareContainer`.
+  - Check SDK version in `nitrokey.nk3.updates.Updater.update`.
+  - Add `nitrokey.nk3.updates.Warning.SDK_VERSION` variant.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)
 

--- a/src/nitrokey/trussed/_bootloader/__init__.py
+++ b/src/nitrokey/trussed/_bootloader/__init__.py
@@ -100,6 +100,7 @@ def _validate_checksum(checksums: dict[str, str], path: str, data: bytes) -> Non
 class FirmwareContainer:
     version: Version
     pynitrokey: Optional[Version]
+    sdk: Optional[Version]
     images: Dict[Variant, bytes]
 
     @classmethod
@@ -121,6 +122,9 @@ class FirmwareContainer:
             pynitrokey = None
             if "pynitrokey" in manifest:
                 pynitrokey = Version.from_v_str(manifest["pynitrokey"])
+            sdk = None
+            if "sdk" in manifest:
+                sdk = Version.from_v_str(manifest["sdk"])
 
             images = {}
             for variant, image in manifest["images"].items():
@@ -131,6 +135,7 @@ class FirmwareContainer:
             return cls(
                 version=version,
                 pynitrokey=pynitrokey,
+                sdk=sdk,
                 images=images,
             )
 


### PR DESCRIPTION
We already support setting a minimum pynitrokey version.  This is no longer useful after extracting the update logic into the SDK, so this patch introduces a minimum SDK version requirement that replaces the pynitrokey version requirement if set.  The current SDK version is determined with importlib.metadata.version.