### PR TITLE
Add support for updates to Nitrokey 3 v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `nitrokey.nk3.updates`:
   - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
   - Show warning when updating from bootloader mode and if the status command is not available.
+  - Reboot devices in firmware mode before the update to make sure that the status is up to date.
   - Add `Warning` enum, `show_warning` and `raise_warning` methods to `UpdateUi` and `ignore_warnings` argument to `UpdateUi.__init__`.
 - Add support for updates to Nitrokey 3 firmware v1.8.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Bump minimum Python version from 3.9 to 3.9.2.
-- `nitrokey.nk3.updates`: Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
+- `nitrokey.nk3.updates`:
+  - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
+  - Show warning when updating from bootloader mode and add `confirm_update_from_bootloader` method to `UpdateUi`.
 - Add support for updates to Nitrokey 3 firmware v1.8.2.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Bump minimum Python version from 3.9 to 3.9.2.
 - `nitrokey.nk3.updates`:
   - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
-  - Show warning when updating from bootloader mode and add `confirm_update_from_bootloader` method to `UpdateUi`.
+  - Show warning when updating from bootloader mode.
+  - Add `Warning` enum, `show_warning` and `raise_warning` methods to `UpdateUi` and `ignore_warnings` argument to `UpdateUi.__init__`.
 - Add support for updates to Nitrokey 3 firmware v1.8.2.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Bump minimum Python version from 3.9 to 3.9.2.
 - `nitrokey.nk3.updates`:
   - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
-  - Show warning when updating from bootloader mode.
+  - Show warning when updating from bootloader mode and if the status command is not available.
   - Add `Warning` enum, `show_warning` and `raise_warning` methods to `UpdateUi` and `ignore_warnings` argument to `UpdateUi.__init__`.
 - Add support for updates to Nitrokey 3 firmware v1.8.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bump minimum Python version from 3.9 to 3.9.2.
+- `nitrokey.nk3.updates`: Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump minimum Python version from 3.9 to 3.9.2.
 - `nitrokey.nk3.updates`: Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
+- Add support for updates to Nitrokey 3 firmware v1.8.2.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1564,4 +1564,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.2"
-content-hash = "0c87619f04b6656a5d103d60e4bd844bd0448fa2ccc4d8ab563ce60a1b18e675"
+content-hash = "5d5d9b3cce69cfac4da06be588e06746fc6a6a8aaab9b368f87316fb4c98bc93"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rstcheck = { version = "^6", extras = ["sphinx"] }
 sphinx = "^7"
 types-protobuf = "^5.26"
 types-requests = "^2.32"
-typing-extensions = "^4"
+typing-extensions = "^4.1"
 
 [tool.black]
 target-version = ["py39"]

--- a/src/nitrokey/nk3/updates.py
+++ b/src/nitrokey/nk3/updates.py
@@ -137,6 +137,10 @@ class UpdateUi(ABC):
         pass
 
     @abstractmethod
+    def confirm_update_from_bootloader(self) -> None:
+        pass
+
+    @abstractmethod
     def confirm_pynitrokey_version(self, current: Version, required: Version) -> None:
         pass
 
@@ -198,6 +202,9 @@ class Updater:
         update_version: Optional[str],
         ignore_pynitrokey_version: bool = False,
     ) -> Version:
+        if isinstance(device, NK3Bootloader):
+            self.ui.confirm_update_from_bootloader()
+
         current_version = device.admin.version() if isinstance(device, NK3) else None
         status = device.admin.status() if isinstance(device, NK3) else None
         logger.info(f"Firmware version before update: {current_version or ''}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,27 +25,29 @@ class TestBasic(unittest.TestCase):
 
 class TestNk3Updates(unittest.TestCase):
     def test_update_path_default(self) -> None:
-        from nitrokey.nk3.updates import UpdatePath
+        from nitrokey.nk3.updates import _Migration
         from nitrokey.trussed import Variant, Version
 
         self.assertEqual(
-            UpdatePath.create(Variant.NRF52, Version(1, 0, 0), Version(1, 1, 0)),
-            UpdatePath.default,
+            _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 1, 0)),
+            frozenset(),
         )
 
     def test_update_path_match(self) -> None:
-        from nitrokey.nk3.updates import UpdatePath
+        from nitrokey.nk3.updates import _Migration
         from nitrokey.trussed import Variant, Version
 
+        nrf_migration = frozenset([_Migration.NRF_IFS_MIGRATION])
+
         self.assertEqual(
-            UpdatePath.create(Variant.NRF52, Version(1, 2, 2), Version(1, 3, 0)),
-            UpdatePath.nRF_IFS_Migration_v1_3,
+            _Migration.get(Variant.NRF52, Version(1, 2, 2), Version(1, 3, 0)),
+            nrf_migration,
         )
         self.assertEqual(
-            UpdatePath.create(Variant.NRF52, Version(1, 0, 0), Version(1, 3, 0)),
-            UpdatePath.nRF_IFS_Migration_v1_3,
+            _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 3, 0)),
+            nrf_migration,
         )
         self.assertEqual(
-            UpdatePath.create(Variant.NRF52, None, Version(1, 3, 0)),
-            UpdatePath.nRF_IFS_Migration_v1_3,
+            _Migration.get(Variant.NRF52, None, Version(1, 3, 0)),
+            nrf_migration,
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,7 +33,11 @@ class TestNk3Updates(unittest.TestCase):
             frozenset(),
         )
         self.assertEqual(
-            _Migration.get(None, Version(1, 8, 2), Version(1, 9, 0)),
+            _Migration.get(Variant.NRF52, Version(1, 8, 2), Version(1, 9, 0)),
+            frozenset(),
+        )
+        self.assertEqual(
+            _Migration.get(Variant.LPC55, Version(1, 2, 2), Version(1, 3, 0)),
             frozenset(),
         )
 
@@ -67,7 +71,11 @@ class TestNk3Updates(unittest.TestCase):
             migrations,
         )
         self.assertEqual(
-            _Migration.get(None, Version(1, 8, 0), Version(1, 8, 2)),
+            _Migration.get(Variant.LPC55, Version(1, 1, 0), Version(1, 8, 2)),
+            migrations,
+        )
+        self.assertEqual(
+            _Migration.get(Variant.LPC55, Version(1, 8, 0), Version(1, 8, 2)),
             migrations,
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,22 +32,54 @@ class TestNk3Updates(unittest.TestCase):
             _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 1, 0)),
             frozenset(),
         )
+        self.assertEqual(
+            _Migration.get(None, Version(1, 8, 2), Version(1, 9, 0)),
+            frozenset(),
+        )
 
-    def test_update_path_match(self) -> None:
+    def test_update_path_nrf(self) -> None:
         from nitrokey.nk3.updates import _Migration
         from nitrokey.trussed import Variant, Version
 
-        nrf_migration = frozenset([_Migration.NRF_IFS_MIGRATION])
+        migrations = frozenset([_Migration.NRF_IFS_MIGRATION])
 
         self.assertEqual(
             _Migration.get(Variant.NRF52, Version(1, 2, 2), Version(1, 3, 0)),
-            nrf_migration,
+            migrations,
         )
         self.assertEqual(
             _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 3, 0)),
-            nrf_migration,
+            migrations,
         )
         self.assertEqual(
             _Migration.get(Variant.NRF52, None, Version(1, 3, 0)),
-            nrf_migration,
+            migrations,
+        )
+
+    def test_update_path_ifs_v2(self) -> None:
+        from nitrokey.nk3.updates import _Migration
+        from nitrokey.trussed import Variant, Version
+
+        migrations = frozenset([_Migration.IFS_MIGRATION_V2])
+
+        self.assertEqual(
+            _Migration.get(Variant.NRF52, Version(1, 5, 0), Version(1, 8, 2)),
+            migrations,
+        )
+        self.assertEqual(
+            _Migration.get(None, Version(1, 8, 0), Version(1, 8, 2)),
+            migrations,
+        )
+
+    def test_update_path_multi(self) -> None:
+        from nitrokey.nk3.updates import _Migration
+        from nitrokey.trussed import Variant, Version
+
+        migrations = frozenset(
+            [_Migration.NRF_IFS_MIGRATION, _Migration.IFS_MIGRATION_V2]
+        )
+
+        self.assertEqual(
+            _Migration.get(Variant.NRF52, Version(1, 2, 2), Version(1, 8, 2)),
+            migrations,
         )


### PR DESCRIPTION
This patch adds support for updating the Nitrokey 3 to firmware v1.8.2 or newer by adding the required checks for the migration of the internal filesystem to version 2 (FIDO2 RK flattening).  The main changes are:

- Remove `UpdatePath` and related functions from the public API as these are implementation details of the `Updater`.
- Replace the single `UpdatePath` with a set of `Migration`s to reflect the fact that there can be multiple migrations happening at once.
- Try to run the migration checks early if possible – otherwise we can be in a situation where the update fails due to missing IFS space, the device stays in bootloader mode and re-running the update skips the checks because the device is in bootloader mode.
- Add a warning when updating from bootloader mode.

For discussion:
1. Should we try to reboot the device into firmware mode if it is in bootloader mode?
2. This skips the checks if we cannot read the remaining IFS blocks due to a very old firmware (1.3?).  Should we abort or show a warning instead?
3. As the IFS block count is determined at boot, it could theoretically be out of date when running the update.  I think this is an acceptable race condition, but we could also force a reboot to avoid this problem (could be combined with 1 to always reboot).