### PR TITLE
docs: Add package version to index

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+import importlib.metadata
+
+
 project = 'Nitrokey Python SDK'
 copyright = '2024, Nitrokey'
 author = 'Nitrokey'
@@ -9,3 +12,7 @@ html_theme = 'alabaster'
 autodoc_class_signature = 'separated'
 autodoc_member_order = 'groupwise'
 autodoc_typehints = 'description'
+
+
+nitrokey_sdk_version = importlib.metadata.version("nitrokey")
+rst_epilog = f".. |nitrokey_sdk_version| replace:: v{nitrokey_sdk_version}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Nitrokey Python SDK
-===================
+Nitrokey Python SDK |nitrokey_sdk_version|
+==========================================
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,4 @@ strict = true
 
 [tool.rstcheck]
 ignore_directives = ["autoclass", "autofunction", "automodule"]
+ignore_substitutions = ["nitrokey_sdk_version"]


### PR DESCRIPTION
This patch adds a custom substitution to the Sphinx conf.py that makes it possible to reference the SDK version in the docs.  This is necessary for the integration into docs.nitrokey.com where we cannot use the version setting to indicate the package version.

Fixes: https://github.com/Nitrokey/nitrokey-sdk-py/issues/64

----

This means that the version will show up in the navigation on docs.nitrokey.com but I think that’s fine.  Alternatively, we could add it to the body only.

![docs](https://github.com/user-attachments/assets/cc56ac7d-f407-4335-be79-0504b2478154)
