### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+-
+
+[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.0...HEAD)
+
+## [v0.3.0](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.3.0) (2025-03-21)
+
 - Bump minimum Python version from 3.9 to 3.9.2.
 - `nitrokey.nk3.updates`:
   - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
@@ -15,7 +21,7 @@
   - Check SDK version in `nitrokey.nk3.updates.Updater.update`.
   - Add `nitrokey.nk3.updates.Warning.SDK_VERSION` variant.
 
-[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.2.4...HEAD)
+[All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.0...HEAD)
 
 ## [v0.2.4](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.2.4) (2025-01-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump minimum Python version from 3.9 to 3.9.2.
 - `nitrokey.nk3.updates`:
   - Remove `UpdatePath`, `get_extra_information` and `get_finalization_wait_retries` from public API.
+  - Remove obsolete `UpdateUi.request_repeated_update` method.
   - Show warning when updating from bootloader mode and if the status command is not available.
   - Reboot devices in firmware mode before the update to make sure that the status is up to date.
   - Add `Warning` enum, `show_warning` and `raise_warning` methods to `UpdateUi` and `ignore_warnings` argument to `UpdateUi.__init__`.

--- a/ci-scripts/linux/rpm/python3-nitrokey.spec
+++ b/ci-scripts/linux/rpm/python3-nitrokey.spec
@@ -1,5 +1,5 @@
 Name:           python3-nitrokey
-Version:        0.2.4
+Version:        0.3.0
 Release:        %autorelease
 Summary:        Python SDK for Nitrokey devices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nitrokey"
-version = "0.2.4"
+version = "0.3.0"
 description = "Nitrokey Python SDK"
 authors = ["Nitrokey <pypi@nitrokey.com>"]
 license = "Apache-2.0 or MIT"

--- a/src/nitrokey/nk3/updates.py
+++ b/src/nitrokey/nk3/updates.py
@@ -10,7 +10,6 @@ import importlib.metadata
 import logging
 import platform
 import time
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Set
 from contextlib import contextmanager
@@ -215,12 +214,6 @@ class UpdateUi(ABC):
     @abstractmethod
     def confirm_update_same_version(self, version: Version) -> None:
         pass
-
-    def request_repeated_update(self) -> Optional[Exception]:
-        warnings.warn(
-            "UpdateUi.request_repeated_update is no longer needed", DeprecationWarning
-        )
-        return None
 
     @abstractmethod
     def pre_bootloader_hint(self) -> None:


### PR DESCRIPTION
This release extends the nitrokey.nk3.updates module and adds support
for updating to Nitrokey 3 firmware v1.8.2.