### PR TITLE
ci: Use Poetry 2 for updating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
-        run: pip install "${POETRY_SPEC}"
+        run: pip install "poetry==2"
       - name: Create virtual environment
         run: make install
       - name: Update locked dependencies


### PR DESCRIPTION
This fixes an issue with virtualenv 20.31.0 and Poetry 1, see: https://github.com/python-poetry/poetry/issues/10378