### PR TITLE
Add support for fido2 v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,3 +198,26 @@ jobs:
         run: /github/home/.cargo/bin/tangler python < README.md > readme.py
       - name: Run code from readme
         run: poetry run python readme.py
+  test-fido2-v2:
+    name: Test against fido2 v2
+    runs-on: ubuntu-latest
+    container: python:3.10-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install required packages
+        run: apt update && apt install -y ${REQUIRED_PACKAGES}
+      - name: Install Poetry
+        run: pip install "poetry==2"
+      - name: Bump Python version
+        run: |
+          sed --in-place 's/python = ".*"/python = "^3.10"/' pyproject.toml
+          sed --in-place 's/python_version = ".*"/python_version = "3.10"/' pyproject.toml
+      - name: Update fido2 to v2
+        run: poetry add --lock "fido2@^2"
+      - name: Create virtual environment
+        run: make install
+      - name: Check code static typing
+        run: make check-typing
+      - name: Run test suite
+        run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add support `fido2` v2.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.1...HEAD)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1652,4 +1652,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.2"
-content-hash = "5d5d9b3cce69cfac4da06be588e06746fc6a6a8aaab9b368f87316fb4c98bc93"
+content-hash = "d258374ab688b955be7b5e878a3733016d426097f5178ab1a0b1e829e3604f16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [
 
 [tool.poetry.dependencies]
 cryptography = ">=41"
-fido2 = "^1.1.2"
+fido2 = ">=1.1.2, <3"
 python = "^3.9.2"
 requests = "^2"
 semver = "^3"


### PR DESCRIPTION
The breaking changes in the fido2 v2.0.0 release do not affect this project so we can allow both v1 and v2.

See the release notes and the migration guide for more information:
- https://github.com/Yubico/python-fido2/releases/tag/2.0.0
- https://github.com/Yubico/python-fido2/blob/2.0.0/doc/Migration_1-2.adoc

Fixes: https://github.com/Nitrokey/nitrokey-sdk-py/issues/76