### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -13,7 +13,7 @@ jobs:
   check-package-version:
     name: Check package version
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     needs: check-package-version
     steps:
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
   check-tag-version:
     name: Check tag version
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     if: github.event_name == 'release'
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   format-code:
     name: Check code format
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
   format-import:
     name: Check imports sorting
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
   lint-style:
     name: Check code style
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
   lint-typing:
     name: Check static typing
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
   lint-poetry:
     name: Check poetry configuration
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
   lint-docs:
     name: Check documentation
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
   test:
     name: Run test suite
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -148,7 +148,7 @@ jobs:
   test-update:
     name: Run test suite with updated dependencies
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install SDK
         run: pip install .
       - name: Run test suite
@@ -182,7 +182,7 @@ jobs:
   test-readme:
     name: Run example code from readme
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -209,10 +209,6 @@ jobs:
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
-      - name: Bump Python version
-        run: |
-          sed --in-place 's/python = ".*"/python = "^3.10"/' pyproject.toml
-          sed --in-place 's/python_version = ".*"/python_version = "3.10"/' pyproject.toml
       - name: Update fido2 to v2
         run: poetry add --lock "fido2@^2"
       - name: Create virtual environment
@@ -240,10 +236,6 @@ jobs:
         run: apt update && apt install -y ${REQUIRED_PACKAGES} gcc libffi-dev
       - name: Install uv
         run: pip install uv
-      - name: Bump Python version
-        run: |
-          sed --in-place 's/python = ".*"/python = ">=3.10, <4"/' pyproject.toml
-          sed --in-place 's/python_version = ".*"/python_version = "3.10"/' pyproject.toml
       - name: Lock dependencies
         run: uv lock && uv tree --locked
       - name: Check code static typing

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `nitrokey.trussed.admin_app.InitStatus`: add support for `EXT_FLASH_NEED_REFORMAT`
 - `nitrokey.nk3.updates`: return device status after an update
 - Use `poetry-core` v2 as build backend.
+- Bump minimum Python version to 3.10.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.2...HEAD)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ for device in NKPK.list():
 
 ## Compatibility
 
-The Nitrokey Python SDK currently requires Python 3.9.2 or later.
+The Nitrokey Python SDK currently requires Python 3.10 or later.
 Support for old Python versions may be dropped in minor releases.
 
 ## Related Projects
@@ -64,7 +64,7 @@ Support for old Python versions may be dropped in minor releases.
 
 The following software is required for the development of the SDK:
 
-- Python 3.9 or newer
+- Python 3.10 or newer
 - [poetry](https://python-poetry.org/)
 - GNU Make
 - git

--- a/poetry.lock
+++ b/poetry.lock
@@ -587,31 +587,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version < \"3.10\""
-files = [
-    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
-    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib_resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "isort"
 version = "5.13.2"
 description = "A Python utility / library to sort Python imports."
@@ -1276,7 +1251,6 @@ babel = ">=2.13"
 colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
 docutils = ">=0.20,<0.22"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=6.0", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.1"
 packaging = ">=23.0"
 Pygments = ">=2.17"
@@ -1413,7 +1387,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -1628,28 +1602,7 @@ files = [
     {file = "wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.23.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version < \"3.10\""
-files = [
-    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
-    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9.2, <4"
-content-hash = "4da79b57afd8be1c9c8405485b1a9acb1cd89ca8a540e27b2a4a6cdfd7ac6032"
+python-versions = ">=3.10, <4"
+content-hash = "72c85d93cdb254c40ca2908ea5dd6e59411f60094f6c6bb3a2b1cd6454084994"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 packages = [
     { include = "nitrokey", from = "src" },
 ]
-requires-python = ">=3.9.2, <4"
+requires-python = ">=3.10, <4"
 dynamic = ["classifiers"]
 
 dependencies = [
@@ -72,16 +72,16 @@ dev-dependencies = [
 ]
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
-py_version = "39"
+py_version = "310"
 profile = "black"
 
 [tool.mypy]
 mypy_path = "stubs"
 show_error_codes = true
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 
 [tool.rstcheck]


### PR DESCRIPTION
Python 3.9 is close to EOL anyway and no longer used by any major distribution.  Dropping support makes it easier to test all dependency versions as newer versions of fido2 require Python 3.10.