### PR TITLE
Refactor nk3.updates to trussed.updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 ## Unreleased
 
 - `nitrokey.trussed.admin_app.InitStatus`: add support for `EXT_FLASH_NEED_REFORMAT`
-- `nitrokey.nk3.updates`: return device status after an update
 - Use `poetry-core` v2 as build backend.
 - Bump minimum Python version to 3.10.
+- `nitrokey.trussed.Model`: Remove `firmware_repository` and `firmware_pattern` properties.
+- `nitrokey.nk3.updates`:
+  - Move to `nitrokey.trussed.updates` and prepare adding NKPK support.
+  - Return device status after an update.
+  - Add `model` argument to `get_firmware_update` and to the connection callbacks in `Updater`.
+  - Add `get_firmware_repository` method.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.2...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - `nitrokey.nk3.updates`:
   - Move to `nitrokey.trussed.updates` and prepare adding NKPK support.
   - Return device status after an update.
-  - Add `model` argument to `get_firmware_update` and to the connection callbacks in `Updater`.
+  - Add `model` argument to `get_firmware_update`.
   - Add `get_firmware_repository` method.
+  - Replace connection callbacks in `Updater` with `DeviceHandler` class.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.2...HEAD)
 

--- a/docs/api/nitrokey.nk3.rst
+++ b/docs/api/nitrokey.nk3.rst
@@ -9,7 +9,6 @@ nitrokey.nk3
    :maxdepth: 1
 
    nitrokey.nk3.secrets_app
-   nitrokey.nk3.updates
 
 Accessing Nitrokey 3 Devices
 ----------------------------

--- a/docs/api/nitrokey.nk3.updates.rst
+++ b/docs/api/nitrokey.nk3.updates.rst
@@ -1,7 +1,0 @@
-nitrokey.nk3.updates
-====================
-
-.. automodule:: nitrokey.nk3.updates
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/nitrokey.trussed.rst
+++ b/docs/api/nitrokey.trussed.rst
@@ -10,6 +10,7 @@ nitrokey.trussed
 
    nitrokey.trussed.admin_app
    nitrokey.trussed.provisioner_app
+   nitrokey.trussed.updates
 
 Trussed Device Objects
 ----------------------

--- a/docs/api/nitrokey.trussed.updates.rst
+++ b/docs/api/nitrokey.trussed.updates.rst
@@ -1,0 +1,7 @@
+nitrokey.trussed.updates
+========================
+
+.. automodule:: nitrokey.trussed.updates
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/nitrokey/nk3/_bootloader.py
+++ b/src/nitrokey/nk3/_bootloader.py
@@ -8,12 +8,17 @@
 from typing import List, Optional, Sequence
 
 from nitrokey import _VID_NITROKEY
+from nitrokey.trussed._base import Model
 from nitrokey.trussed._bootloader import TrussedBootloader
 from nitrokey.trussed._bootloader.lpc55 import TrussedBootloaderLpc55
 from nitrokey.trussed._bootloader.nrf52 import SignatureKey, TrussedBootloaderNrf52
 
 
 class NK3Bootloader(TrussedBootloader):
+    @property
+    def model(self) -> Model:
+        return Model.NK3
+
     @staticmethod
     def list() -> List["NK3Bootloader"]:
         devices: List[NK3Bootloader] = []

--- a/src/nitrokey/nk3/_device.py
+++ b/src/nitrokey/nk3/_device.py
@@ -10,7 +10,7 @@ from typing import List
 from fido2.hid import CtapHidDevice, list_descriptors, open_device
 
 from nitrokey import _VID_NITROKEY
-from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
+from nitrokey.trussed import Fido2Certs, Model, TrussedDevice, Version
 
 FIDO2_CERTS = [
     Fido2Certs(
@@ -35,6 +35,10 @@ class NK3(TrussedDevice):
 
     def __init__(self, device: CtapHidDevice) -> None:
         super().__init__(device, FIDO2_CERTS)
+
+    @property
+    def model(self) -> Model:
+        return Model.NK3
 
     @property
     def pid(self) -> int:

--- a/src/nitrokey/nkpk.py
+++ b/src/nitrokey/nkpk.py
@@ -11,6 +11,7 @@ from fido2.hid import CtapHidDevice, list_descriptors, open_device
 
 from nitrokey import _VID_NITROKEY
 from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
+from nitrokey.trussed._base import Model
 from nitrokey.trussed._bootloader import ModelData
 from nitrokey.trussed._bootloader.nrf52 import SignatureKey, TrussedBootloaderNrf52
 
@@ -49,6 +50,10 @@ class NKPK(TrussedDevice):
         super().__init__(device, _FIDO2_CERTS)
 
     @property
+    def model(self) -> Model:
+        return Model.NKPK
+
+    @property
     def pid(self) -> int:
         return _PID_NKPK_DEVICE
 
@@ -77,6 +82,10 @@ class NKPK(TrussedDevice):
 
 
 class NKPKBootloader(TrussedBootloaderNrf52):
+    @property
+    def model(self) -> Model:
+        return Model.NKPK
+
     @property
     def name(self) -> str:
         return "Nitrokey Passkey Bootloader"

--- a/src/nitrokey/trussed/__init__.py
+++ b/src/nitrokey/trussed/__init__.py
@@ -5,10 +5,10 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+from ._base import Model as Model  # noqa: F401
 from ._base import TrussedBase as TrussedBase  # noqa: F401
 from ._bootloader import FirmwareContainer as FirmwareContainer  # noqa: F401
 from ._bootloader import FirmwareMetadata as FirmwareMetadata  # noqa: F401
-from ._bootloader import Model as Model  # noqa: F401
 from ._bootloader import TrussedBootloader as TrussedBootloader  # noqa: F401
 from ._bootloader import Variant as Variant  # noqa: F401
 from ._bootloader import parse_firmware_image as parse_firmware_image  # noqa: F401

--- a/src/nitrokey/trussed/_base.py
+++ b/src/nitrokey/trussed/_base.py
@@ -6,6 +6,7 @@
 # copied, modified, or distributed except according to those terms.
 
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Optional, TypeVar
 
 from nitrokey import _VID_NITROKEY
@@ -13,6 +14,21 @@ from nitrokey import _VID_NITROKEY
 from ._utils import Uuid
 
 T = TypeVar("T", bound="TrussedBase")
+
+
+class Model(Enum):
+    NK3 = "Nitrokey 3"
+    NKPK = "Nitrokey Passkey"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_str(cls, s: str) -> "Model":
+        for model in cls:
+            if model.value == s:
+                return model
+        raise ValueError(f"Unknown model {s}")
 
 
 class TrussedBase(ABC):
@@ -33,6 +49,10 @@ class TrussedBase(ABC):
                 f"Not a {self.name} device: expected VID:PID "
                 f"{self.vid:x}:{self.pid:x}, got {vid:x}:{pid:x}"
             )
+
+    @property
+    @abstractmethod
+    def model(self) -> Model: ...
 
     @property
     def vid(self) -> int:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,69 +25,87 @@ class TestBasic(unittest.TestCase):
 
 class TestNk3Updates(unittest.TestCase):
     def test_update_path_default(self) -> None:
-        from nitrokey.nk3.updates import _Migration
-        from nitrokey.trussed import Variant, Version
+        from nitrokey.trussed import Model, Variant, Version
+        from nitrokey.trussed.updates import _Migration
 
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 1, 0)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 0, 0), Version(1, 1, 0)
+            ),
             frozenset(),
         )
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 8, 2), Version(1, 9, 0)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 8, 2), Version(1, 9, 0)
+            ),
             frozenset(),
         )
         self.assertEqual(
-            _Migration.get(Variant.LPC55, Version(1, 2, 2), Version(1, 3, 0)),
+            _Migration.get(
+                Model.NK3, Variant.LPC55, Version(1, 2, 2), Version(1, 3, 0)
+            ),
             frozenset(),
         )
 
     def test_update_path_nrf(self) -> None:
-        from nitrokey.nk3.updates import _Migration
-        from nitrokey.trussed import Variant, Version
+        from nitrokey.trussed import Model, Variant, Version
+        from nitrokey.trussed.updates import _Migration
 
         migrations = frozenset([_Migration.NRF_IFS_MIGRATION])
 
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 2, 2), Version(1, 3, 0)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 2, 2), Version(1, 3, 0)
+            ),
             migrations,
         )
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 0, 0), Version(1, 3, 0)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 0, 0), Version(1, 3, 0)
+            ),
             migrations,
         )
         self.assertEqual(
-            _Migration.get(Variant.NRF52, None, Version(1, 3, 0)),
+            _Migration.get(Model.NK3, Variant.NRF52, None, Version(1, 3, 0)),
             migrations,
         )
 
     def test_update_path_ifs_v2(self) -> None:
-        from nitrokey.nk3.updates import _Migration
-        from nitrokey.trussed import Variant, Version
+        from nitrokey.trussed import Model, Variant, Version
+        from nitrokey.trussed.updates import _Migration
 
         migrations = frozenset([_Migration.IFS_MIGRATION_V2])
 
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 5, 0), Version(1, 8, 2)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 5, 0), Version(1, 8, 2)
+            ),
             migrations,
         )
         self.assertEqual(
-            _Migration.get(Variant.LPC55, Version(1, 1, 0), Version(1, 8, 2)),
+            _Migration.get(
+                Model.NK3, Variant.LPC55, Version(1, 1, 0), Version(1, 8, 2)
+            ),
             migrations,
         )
         self.assertEqual(
-            _Migration.get(Variant.LPC55, Version(1, 8, 0), Version(1, 8, 2)),
+            _Migration.get(
+                Model.NK3, Variant.LPC55, Version(1, 8, 0), Version(1, 8, 2)
+            ),
             migrations,
         )
 
     def test_update_path_multi(self) -> None:
-        from nitrokey.nk3.updates import _Migration
-        from nitrokey.trussed import Variant, Version
+        from nitrokey.trussed import Model, Variant, Version
+        from nitrokey.trussed.updates import _Migration
 
         migrations = frozenset(
             [_Migration.NRF_IFS_MIGRATION, _Migration.IFS_MIGRATION_V2]
         )
 
         self.assertEqual(
-            _Migration.get(Variant.NRF52, Version(1, 2, 2), Version(1, 8, 2)),
+            _Migration.get(
+                Model.NK3, Variant.NRF52, Version(1, 2, 2), Version(1, 8, 2)
+            ),
             migrations,
         )


### PR DESCRIPTION
This patch moves the nk3.updates module to trussed.updates and makes it
independent of the model.  This is a preparation for applying NKPK
firmware updates.