### PR TITLE
Add support for protobuf v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add support for `protobuf` v6.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.4.0...HEAD)
 
@@ -23,7 +23,7 @@
 
 ## [v0.3.2](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.3.2) (2025-07-08)
 
-- Add support `fido2` v2.
+- Add support for `fido2` v2.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.3.1...v0.3.2)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1605,4 +1605,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "72c85d93cdb254c40ca2908ea5dd6e59411f60094f6c6bb3a2b1cd6454084994"
+content-hash = "50d9098be4b28ec32e2a90380e814e870de37ea7947ca366e7c8a7eb864865ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "hidapi >=0.14, <0.15",
 
     # nrf52
-    "protobuf >=5.26, <6",
+    "protobuf >=5.26, <7",
     "pyserial >=3.5, <4",
 ]
 
@@ -52,7 +52,7 @@ isort = "^5.13.2"
 mypy = "^1.4"
 rstcheck = { version = "^6", extras = ["sphinx"] }
 sphinx = "^7"
-types-protobuf = "^5.26"
+types-protobuf = ">=5.26, <7"
 types-requests = "^2.16"
 typing-extensions = "^4.1"
 
@@ -61,7 +61,7 @@ dev-dependencies = [
     # These dependencies are required for running the type checks.
     "fake-winreg >=1.6, <2",
     "mypy >=1.4, <2",
-    "types-protobuf >=5.26, <6",
+    "types-protobuf >=5.26, <7",
     "types-requests >=2.16, <3",
 
     # These additional lower bounds are required for --resolution lowest.


### PR DESCRIPTION
Compatibility is tested in the test suite.  Also, code generated with the breaking v30 of protoc does not contain relevant changes to our generated code.

See also:
- https://github.com/protocolbuffers/protobuf/releases/tag/v30.0
- https://protobuf.dev/support/migration/#v30

Fixes: https://github.com/Nitrokey/nitrokey-sdk-py/issues/84