### PR TITLE
Update Makefile for poetry v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ MYPY ?= poetry run mypy
 
 .PHONY: install
 install:
-	poetry install --sync --with dev
+	poetry sync --with dev
 
 .PHONY: lock
 lock:
-	poetry lock --no-update
+	poetry lock
 
 .PHONY: update
 update:


### PR DESCRIPTION
Poetry v2 replaced `install --sync` with the `sync` command and made the `--no-update` option the default for the `lock` command, see:

https://python-poetry.org/blog/announcing-poetry-2.0.0/