### PR TITLE
trussed.admin_app: Fix validation of ConfigFieldType.U8 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for `protobuf` v6.
+- `nitrokey.trussed.admin_app`: Fix validation of `ConfigFieldType.U8` values.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.4.0...HEAD)
 

--- a/src/nitrokey/trussed/admin_app.py
+++ b/src/nitrokey/trussed/admin_app.py
@@ -170,7 +170,7 @@ class ConfigFieldType(Enum):
         elif self == ConfigFieldType.U8:
             try:
                 intval = int(value)
-                if intval < 256 and intval > 0:
+                if intval < 256 and intval >= 0:
                     return True
                 else:
                     return False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -109,3 +109,37 @@ class TestNk3Updates(unittest.TestCase):
             ),
             migrations,
         )
+
+
+class TestConfigFieldType(unittest.TestCase):
+    def test_is_valid_bool(self) -> None:
+        from nitrokey.trussed.admin_app import ConfigFieldType
+
+        t = ConfigFieldType.BOOL
+
+        self.assertTrue(t.is_valid("true"))
+        self.assertTrue(t.is_valid("false"))
+
+        self.assertFalse(t.is_valid(""))
+        self.assertFalse(t.is_valid("True"))
+        self.assertFalse(t.is_valid("False"))
+        self.assertFalse(t.is_valid("0"))
+        self.assertFalse(t.is_valid("1"))
+        self.assertFalse(t.is_valid("something else"))
+
+    def test_is_valid_u8(self) -> None:
+        from nitrokey.trussed.admin_app import ConfigFieldType
+
+        t = ConfigFieldType.U8
+
+        self.assertTrue(t.is_valid("0"))
+        self.assertTrue(t.is_valid("1"))
+        self.assertTrue(t.is_valid("42"))
+        self.assertTrue(t.is_valid("255"))
+
+        self.assertFalse(t.is_valid(""))
+        self.assertFalse(t.is_valid("-1"))
+        self.assertFalse(t.is_valid("256"))
+        self.assertFalse(t.is_valid("4242"))
+        self.assertFalse(t.is_valid("something else"))
+        self.assertFalse(t.is_valid("True"))


### PR DESCRIPTION
Zero is a valid U8 value.  This patch also adds basic tests for ConfigFieldType.is_valid.