### PR TITLE
ci: Update triggers to reduce duplicate runs

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -1,10 +1,12 @@
 name: Continuous delivery - PyPI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   POETRY_SPEC: poetry >=2, <3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 env:
   REQUIRED_PACKAGES: make


### PR DESCRIPTION
This patch disables workflow runs for pushes to branches other than main to reduce duplicate workflow runs for PRs.  If a workflow should be run for a branch without a PR, it can still be triggered manually.