### PR TITLE
ci: Pin wrapt to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ dev-dependencies = [
     "cffi >=1.14.1",
     "typing-extensions >=4.1",
     "urllib3 >= 2",
+
+    # fake-winreg does not work with wrapt v2 so we need to add an additional upper bound
+    "wrapt <2",
 ]
 
 [tool.black]


### PR DESCRIPTION
wrapt v2, a dependency of fake-winreg, causes a typing error in the CI when testing against the latest dependency versions. Thus this patch adds an explicit upper bound.