### PR TITLE
Add experimental type checks with ty

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,6 @@ jobs:
       - name: Lock dependencies
         run: uv lock && uv tree --locked
       - name: Check code static typing
-        run: make check-typing MYPY="uv run --locked mypy"
+        run: make check-typing MYPY="uv run --locked mypy" TY="uv run --locked ty"
       - name: Run test suite
         run: make test PYTHON="uv run --locked python"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LINT_DIRS := src tests
 PYTHON ?= poetry run python
 MYPY ?= poetry run mypy
 RUFF ?= poetry run ruff
+TY ?= poetry run ty
 
 .PHONY: install
 install:
@@ -36,6 +37,7 @@ check-style:
 
 .PHONY: check-typing
 check-typing:
+	$(TY) check
 	$(MYPY) $(LINT_DIRS)
 
 .PHONY: check-docs

--- a/poetry.lock
+++ b/poetry.lock
@@ -1605,6 +1605,33 @@ files = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.16"
+description = "An extremely fast Python type checker, written in Rust."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "ty-0.0.16-py3-none-linux_armv6l.whl", hash = "sha256:6d8833b86396ed742f2b34028f51c0e98dbf010b13ae4b79d1126749dc9dab15"},
+    {file = "ty-0.0.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:934c0055d3b7f1cf3c8eab78c6c127ef7f347ff00443cef69614bda6f1502377"},
+    {file = "ty-0.0.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b55e8e8733b416d914003cd22e831e139f034681b05afed7e951cc1a5ea1b8d4"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feccae8f4abd6657de111353bd604f36e164844466346eb81ffee2c2b06ea0f0"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1cad5e29d8765b92db5fa284940ac57149561f3f89470b363b9aab8a6ce553b0"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86f28797c7dc06f081238270b533bf4fc8e93852f34df49fb660e0b58a5cda9a"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be971a3b42bcae44d0e5787f88156ed2102ad07558c05a5ae4bfd32a99118e66"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c9f982b7c4250eb91af66933f436b3a2363c24b6353e94992eab6551166c8b7"},
+    {file = "ty-0.0.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d122edf85ce7bdf6f85d19158c991d858fc835677bd31ca46319c4913043dc84"},
+    {file = "ty-0.0.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:497ebdddbb0e35c7758ded5aa4c6245e8696a69d531d5c9b0c1a28a075374241"},
+    {file = "ty-0.0.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e1e0ac0837bde634b030243aeba8499383c0487e08f22e80f5abdacb5b0bd8ce"},
+    {file = "ty-0.0.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1216c9bcca551d9f89f47a817ebc80e88ac37683d71504e5509a6445f24fd024"},
+    {file = "ty-0.0.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:221bbdd2c6ee558452c96916ab67fcc465b86967cf0482e19571d18f9c831828"},
+    {file = "ty-0.0.16-py3-none-win32.whl", hash = "sha256:d52c4eb786be878e7514cab637200af607216fcc5539a06d26573ea496b26512"},
+    {file = "ty-0.0.16-py3-none-win_amd64.whl", hash = "sha256:f572c216aa8ecf79e86589c6e6d4bebc01f1f3cb3be765c0febd942013e1e73a"},
+    {file = "ty-0.0.16-py3-none-win_arm64.whl", hash = "sha256:430eadeb1c0de0c31ef7bef9d002bdbb5f25a31e3aad546f1714d76cd8da0a87"},
+    {file = "ty-0.0.16.tar.gz", hash = "sha256:a999b0db6aed7d6294d036ebe43301105681e0c821a19989be7c145805d7351c"},
+]
+
+[[package]]
 name = "typer"
 version = "0.24.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1791,4 +1818,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "b9782daafd3d669b716542d7343e5f8cf1b541cb51f0baa196d55470d34330af"
+content-hash = "37efa58c59f7c246b94989dc3d3e1f4bf6fe538dd46a9ba569556175cedce6e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ mypy = "^1.4"
 rstcheck = { version = "^6", extras = ["sphinx"] }
 ruff = "^0.14"
 sphinx = "^7"
+ty = "^0.0.16"
 types-protobuf = ">=5.26, <7"
 types-requests = "^2.16"
 typing-extensions = "^4.1"
@@ -64,6 +65,7 @@ dev-dependencies = [
     # These dependencies are required for running the type checks.
     "fake-winreg >=1.6, <2",
     "mypy >=1.4, <2",
+    "ty >=0.0.16, <0.0.17",
     "types-protobuf >=5.26, <7",
     "types-requests >=2.16, <3",
 
@@ -102,3 +104,10 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint.mccabe]
 max-complexity = 30
+
+[tool.ty.environment]
+extra-paths = ["stubs"]
+
+[tool.ty.rules]
+# some type: ignore comments are only needed for mypy so ty should not report them as unused
+unused-type-ignore-comment = "ignore"

--- a/src/nitrokey/_smartcard.py
+++ b/src/nitrokey/_smartcard.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from typing import Any
+
+try:
+    from smartcard.ExclusiveConnectCardConnection import (
+        ExclusiveConnectCardConnection as ExclusiveConnectCardConnection,
+    )
+    from smartcard.ExclusiveTransmitCardConnection import (
+        ExclusiveTransmitCardConnection as ExclusiveTransmitCardConnection,
+    )
+except ModuleNotFoundError:
+
+    class ExclusiveTransmitCardConnection:  # type: ignore[no-redef]
+        def __init__(self, connection: Any) -> None:
+            raise NotImplementedError()
+
+        def connect(self) -> None:
+            raise NotImplementedError()
+
+        def disconnect(self) -> None:
+            raise NotImplementedError()
+
+        def release(self) -> None:
+            raise NotImplementedError()
+
+        def getATR(self) -> list[int]:
+            raise NotImplementedError()
+
+        def transmit(self, data: list[int]) -> tuple[bytes, int, int]:
+            raise NotImplementedError()
+
+        def lock(self) -> None:
+            raise NotImplementedError()
+
+        def unlock(self) -> None:
+            raise NotImplementedError()
+
+        def getReader(self) -> str:
+            raise NotImplementedError()
+
+    class ExclusiveConnectCardConnection:  # type: ignore[no-redef]
+        def __init__(self, connection: Any) -> None:
+            raise NotImplementedError()
+
+        def connect(self) -> None:
+            raise NotImplementedError()
+
+        def disconnect(self) -> None:
+            raise NotImplementedError()
+
+        def release(self) -> None:
+            raise NotImplementedError()
+
+        def getATR(self) -> list[int]:
+            raise NotImplementedError()
+
+        def transmit(self, data: list[int]) -> tuple[bytes, int, int]:
+            raise NotImplementedError()
+
+        def lock(self) -> None:
+            raise NotImplementedError()
+
+        def unlock(self) -> None:
+            raise NotImplementedError()
+
+        def getReader(self) -> str:
+            raise NotImplementedError()

--- a/src/nitrokey/nk3/_device.py
+++ b/src/nitrokey/nk3/_device.py
@@ -9,19 +9,8 @@ from typing import List
 
 from fido2.hid import CtapHidDevice
 
-try:
-    from smartcard.ExclusiveConnectCardConnection import ExclusiveConnectCardConnection
-    from smartcard.ExclusiveTransmitCardConnection import ExclusiveTransmitCardConnection
-except ModuleNotFoundError:
-
-    class ExclusiveTransmitCardConnection:  # type: ignore[no-redef]
-        pass
-
-    class ExclusiveConnectCardConnection:  # type: ignore[no-redef]
-        pass
-
-
 from nitrokey import _VID_NITROKEY
+from nitrokey._smartcard import ExclusiveConnectCardConnection, ExclusiveTransmitCardConnection
 from nitrokey.trussed import Fido2Certs, Model, TrussedDevice, Version
 
 FIDO2_CERTS = [

--- a/src/nitrokey/nkpk.py
+++ b/src/nitrokey/nkpk.py
@@ -10,19 +10,8 @@ from typing import List, Optional, Sequence, Union
 
 from fido2.hid import CtapHidDevice
 
-try:
-    from smartcard.ExclusiveConnectCardConnection import ExclusiveConnectCardConnection
-    from smartcard.ExclusiveTransmitCardConnection import ExclusiveTransmitCardConnection
-except ModuleNotFoundError:
-
-    class ExclusiveTransmitCardConnection:  # type: ignore[no-redef]
-        pass
-
-    class ExclusiveConnectCardConnection:  # type: ignore[no-redef]
-        pass
-
-
 from nitrokey import _VID_NITROKEY
+from nitrokey._smartcard import ExclusiveConnectCardConnection, ExclusiveTransmitCardConnection
 from nitrokey.trussed import Fido2Certs, TrussedDevice, Version
 from nitrokey.trussed._base import Model
 from nitrokey.trussed._bootloader import ModelData

--- a/src/nitrokey/trussed/_bootloader/lpc55.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55.py
@@ -100,7 +100,7 @@ class TrussedBootloaderLpc55(TrussedBootloader):
             try:
                 devices.append(cls(device))
             except ValueError:
-                logger.warn(
+                logger.warning(
                     f"Invalid Nitrokey 3 LPC55 bootloader returned by enumeration: {device}"
                 )
         return devices
@@ -109,16 +109,16 @@ class TrussedBootloaderLpc55(TrussedBootloader):
     def _open(cls: type[T], path: str) -> Optional[T]:
         devices = UsbDevice.enumerate(path=path)
         if len(devices) == 0:
-            logger.warn(f"No HID device at {path}")
+            logger.warning(f"No HID device at {path}")
             return None
         if len(devices) > 1:
-            logger.warn(f"Multiple HID devices at {path}: {devices}")
+            logger.warning(f"Multiple HID devices at {path}: {devices}")
             return None
 
         try:
             return cls(devices[0])
         except ValueError:
-            logger.warn(f"No Nitrokey 3 bootloader at path {path}", exc_info=sys.exc_info())
+            logger.warning(f"No Nitrokey 3 bootloader at path {path}", exc_info=sys.exc_info())
             return None
 
 

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/mboot/properties.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/mboot/properties.py
@@ -470,10 +470,10 @@ class AvailableCommandsValue(PropertyValueBase):
     __slots__ = ("value",)
 
     @property
-    def tags(self) -> List[str]:
+    def tags(self) -> List[int]:
         """List of tags representing Available commands."""
         return [
-            cmd_tag.tag  # type: ignore
+            cmd_tag.tag
             for cmd_tag in CommandTag
             if cmd_tag.tag > 0 and (1 << cmd_tag.tag - 1) & self.value
         ]
@@ -492,11 +492,13 @@ class AvailableCommandsValue(PropertyValueBase):
 
     def to_str(self) -> str:
         """Get stringified property representation."""
-        return [
-            cmd_tag.label  # type: ignore
-            for cmd_tag in CommandTag
-            if cmd_tag.tag > 0 and (1 << cmd_tag.tag - 1) & self.value
-        ]
+        return ", ".join(
+            [
+                cmd_tag.label
+                for cmd_tag in CommandTag
+                if cmd_tag.tag > 0 and (1 << cmd_tag.tag - 1) & self.value
+            ]
+        )
 
 
 class IrqNotifierPinValue(PropertyValueBase):

--- a/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/windows/constants.py
+++ b/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/windows/constants.py
@@ -40,10 +40,10 @@ class DiGetClassDevsFlags(enum.IntEnum):
     """DIGCF_xxx constants"""
 
     Default = 0x00000001
-    Present = (0x00000002,)
-    AllClasses = (0x00000004,)
-    Profile = (0x00000008,)
-    DeviceInterface = (0x00000010,)
+    Present = (0x00000002,)  # ty: ignore[invalid-assignment]
+    AllClasses = (0x00000004,)  # ty: ignore[invalid-assignment]
+    Profile = (0x00000008,)  # ty: ignore[invalid-assignment]
+    DeviceInterface = (0x00000010,)  # ty: ignore[invalid-assignment]
 
 
 # noinspection SpellCheckingInspection

--- a/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/windows/lister_win32.py
+++ b/src/nitrokey/trussed/_bootloader/nrf52_upload/lister/windows/lister_win32.py
@@ -136,7 +136,10 @@ def get_serial_serial_no(
 
     hkey_path = "SYSTEM\\CurrentControlSet\\Enum\\USB\\VID_{}&PID_{}".format(vendor_id, product_id)
     try:
-        vendor_product_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+        vendor_product_hkey = winreg.OpenKeyEx(
+            winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+            hkey_path,
+        )
     except EnvironmentError:
         return None
 
@@ -153,7 +156,10 @@ def get_serial_serial_no(
         )
 
         try:
-            device_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+            device_hkey = winreg.OpenKeyEx(
+                winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+                hkey_path,
+            )
         except EnvironmentError:
             continue
 
@@ -185,7 +191,10 @@ def get_serial_serial_no(
 def com_port_is_open(port: str) -> bool:
     hkey_path = "HARDWARE\\DEVICEMAP\\SERIALCOMM"
     try:
-        device_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+        device_hkey = winreg.OpenKeyEx(
+            winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+            hkey_path,
+        )
     except EnvironmentError:
         #  Unable to check enumerated serialports. Assume open.
         return True
@@ -211,7 +220,10 @@ def list_all_com_ports(vendor_id: str, product_id: str, serial_number: str) -> l
     )
 
     try:
-        device_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+        device_hkey = winreg.OpenKeyEx(
+            winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+            hkey_path,
+        )
     except EnvironmentError:
         return ports
 
@@ -227,7 +239,10 @@ def list_all_com_ports(vendor_id: str, product_id: str, serial_number: str) -> l
         vendor_id, product_id, serial_number
     )
     try:
-        device_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+        device_hkey = winreg.OpenKeyEx(
+            winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+            hkey_path,
+        )
         try:
             COM_port = winreg.QueryValueEx(device_hkey, "PortName")[0]
             ports.append(COM_port)
@@ -253,7 +268,10 @@ def list_all_com_ports(vendor_id: str, product_id: str, serial_number: str) -> l
         )
         iface_id += 1
         try:
-            device_hkey = winreg.OpenKeyEx(winreg.HKEY_LOCAL_MACHINE, hkey_path)
+            device_hkey = winreg.OpenKeyEx(
+                winreg.HKEY_LOCAL_MACHINE,  # ty: ignore[possibly-missing-attribute]
+                hkey_path,
+            )
         except EnvironmentError:
             break
 

--- a/src/nitrokey/trussed/_device.py
+++ b/src/nitrokey/trussed/_device.py
@@ -15,17 +15,7 @@ from typing import List, Optional, Sequence, TypeVar, Union
 
 from fido2.hid import CtapHidDevice, list_descriptors, open_device
 
-try:
-    from smartcard.ExclusiveConnectCardConnection import ExclusiveConnectCardConnection
-    from smartcard.ExclusiveTransmitCardConnection import ExclusiveTransmitCardConnection
-except ModuleNotFoundError:
-
-    class ExclusiveTransmitCardConnection:  # type: ignore[no-redef]
-        pass
-
-    class ExclusiveConnectCardConnection:  # type: ignore[no-redef]
-        pass
-
+from nitrokey._smartcard import ExclusiveConnectCardConnection, ExclusiveTransmitCardConnection
 
 from ._base import TrussedBase
 from ._utils import Fido2Certs, Iso7816Apdu, Uuid
@@ -57,6 +47,9 @@ class App(Enum):
             return bytes.fromhex("A00000084700000001")
         elif self == App.PROVISIONER:
             return bytes.fromhex("A00000084700000001")
+        else:
+            # TODO: use typing.assert_never
+            raise ValueError(self)
 
 
 class TrussedDevice(TrussedBase):
@@ -225,12 +218,12 @@ class TrussedDevice(TrussedBase):
             else:
                 device = open_device(path)
         except Exception:
-            logger.warn(f"No CTAPHID device at path {path}", exc_info=sys.exc_info())
+            logger.warning(f"No CTAPHID device at path {path}", exc_info=sys.exc_info())
             return None
         try:
             return cls.from_device(device)
         except ValueError:
-            logger.warn(f"No Nitrokey device at path {path}", exc_info=sys.exc_info())
+            logger.warning(f"No Nitrokey device at path {path}", exc_info=sys.exc_info())
             return None
 
     @classmethod

--- a/src/nitrokey/trussed/admin_app.py
+++ b/src/nitrokey/trussed/admin_app.py
@@ -186,12 +186,18 @@ class ConfigFieldType(Enum):
                     return False
             except ValueError:
                 return False
+        else:
+            # TODO: use typing.assert_never from Python 3.11
+            raise ValueError(self)
 
     def __str__(self) -> str:
         if self == ConfigFieldType.BOOL:
             return "Bool"
         elif self == ConfigFieldType.U8:
             return "u8"
+        else:
+            # TODO: use typing.assert_never from Python 3.11
+            raise ValueError(self)
 
 
 @dataclass


### PR DESCRIPTION
This patch prepares the repository for type checks with ty and adds an experimental CI job that runs the checks.

ty detected these problems in the current code:
- TrussedBootloaderNrf52.update renamed an argument while overriding TrussedBootloader.update
- Some ConfigFieldType functions did not handle unexpected variants. Ideally, we would use typing.assert_never here, but this has only been added in Python 3.11.
- logger.warn is deprecated in favor of logger.warning.

We still have to ignore these false-positives:
- @functools.total_ordering is not handled correctly, see https://github.com/astral-sh/ty/issues/1202
- Some imports from fake-winreg are not handled correctly, but this could also be a problem with fake-winreg.