### PR TITLE
ci: Pin fedora container to 42 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
   check-version-accordance:
     name: Check for version accordance
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:42
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This fixes the CI that failed due to Fedora 43 shipping Python 3.14.