### PR TITLE
make fix: use ruff instead of black + isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ check-docs:
 
 .PHONY: fix
 fix:
-	poetry run black $(FORMAT_DIRS)
-	poetry run isort $(FORMAT_DIRS)
+	$(RUFF) format $(FORMAT_DIRS)
+	$(RUFF) check --fix $(LINT_DIRS)
 
 .PHONY: test
 test:


### PR DESCRIPTION
Was missed in https://github.com/Nitrokey/nitrokey-sdk-py/pull/99