### PR TITLE
ruff: Enable ANN checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ line-length = 100
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-select = ["B", "C", "E", "F", "W", "I"]
-ignore = ["E501"]
+select = ["ANN", "B", "C", "E", "F", "W", "I"]
+ignore = ["ANN401", "E501"]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false

--- a/src/nitrokey/nk3/secrets_app.py
+++ b/src/nitrokey/nk3/secrets_app.py
@@ -300,7 +300,7 @@ class SecretsApp:
     _cache_status: Optional[SelectResponse]
     _metadata: dict[Any, Any]
 
-    def __init__(self, dev: NK3, logfn: Optional[LogFn] = None):
+    def __init__(self, dev: NK3, logfn: Optional[LogFn] = None) -> None:
         self._cache_status = None
         self.write_corpus_fn = None
         self.log = logging.getLogger("otpapp")

--- a/src/nitrokey/trussed/_bootloader/lpc55.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class TrussedBootloaderLpc55(TrussedBootloader):
     """A Nitrokey 3 device running the LPC55 bootloader."""
 
-    def __init__(self, device: UsbDevice):
+    def __init__(self, device: UsbDevice) -> None:
         self._validate_vid_pid(device.vid, device.pid)
         self._path = device.path
         self.device = McuBoot(MbootUSBInterface(device))

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/crypto/symmetric.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/crypto/symmetric.py
@@ -29,7 +29,7 @@ class Counter:
         nonce: bytes,
         ctr_value: Optional[int] = None,
         ctr_byteorder_encoding: Endianness = Endianness.LITTLE,
-    ):
+    ) -> None:
         """Constructor.
 
         :param nonce: last four bytes are used as initial value for counter

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/mboot/properties.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/mboot/properties.py
@@ -49,7 +49,7 @@ def size_fmt(value: Union[int, float], kibibyte: bool = True) -> str:
 class Version:
     """McuBoot current and target version type."""
 
-    def __init__(self, *args: Union[str, int], **kwargs: int):
+    def __init__(self, *args: Union[str, int], **kwargs: int) -> None:
         """Initialize the Version object.
 
         :raises McuBootError: Argument passed the not str not int

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/misc.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/misc.py
@@ -134,7 +134,7 @@ class BcdVersion3:
             return BcdVersion3.from_str(input_version)
         raise SPSDKError("unsupported format")
 
-    def __init__(self, major: int = 1, minor: int = 0, service: int = 0):
+    def __init__(self, major: int = 1, minor: int = 0, service: int = 0) -> None:
         """Initialize BcdVersion3.
 
         :param major: number in BCD format, 1-4 decimal digits

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/commands.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/commands.py
@@ -658,7 +658,7 @@ class CmdMemEnable(CmdBaseClass):
         """Set command's flag."""
         self._header.flags = value
 
-    def __init__(self, address: int, size: int, mem_id: int):
+    def __init__(self, address: int, size: int, mem_id: int) -> None:
         """Initialize CmdMemEnable.
 
         :param address: source address with configuration data for memory initialization
@@ -887,7 +887,7 @@ class CmdKeyStoreBackupRestore(CmdBaseClass):
         """
         raise NotImplementedError("Derived class has to implement this method.")
 
-    def __init__(self, address: int, controller_id: ExtMemId):
+    def __init__(self, address: int, controller_id: ExtMemId) -> None:
         """Initialize CmdKeyStoreBackupRestore.
 
         :param address: where to backup key-store or source for restoring key-store

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/images.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/images.py
@@ -26,7 +26,7 @@ class SBV2xAdvancedParams:
     These parameters are used for the tests; for production, use can use default values (random keys + current time)
     """
 
-    def __init__(self, dek: bytes, mac: bytes, nonce: bytes, timestamp: datetime):
+    def __init__(self, dek: bytes, mac: bytes, nonce: bytes, timestamp: datetime) -> None:
         """Initialize SBV2xAdvancedParams.
 
         :param dek: DEK key

--- a/src/nitrokey/trussed/_bootloader/nrf52_upload/dfu/manifest.py
+++ b/src/nitrokey/trussed/_bootloader/nrf52_upload/dfu/manifest.py
@@ -49,7 +49,7 @@ class FWMetaData:
         softdevice_req: Optional[Any] = None,
         sd_size: Optional[Any] = None,
         bl_size: Optional[Any] = None,
-    ):
+    ) -> None:
         """
         The FWMetaData data model.
 
@@ -77,7 +77,7 @@ class Firmware:
         bin_file: Optional[str] = None,
         dat_file: Optional[str] = None,
         info_read_only_metadata: Optional[dict[str, Any]] = None,
-    ):
+    ) -> None:
         """
         The firmware datamodel
 
@@ -101,7 +101,7 @@ class SoftdeviceBootloaderFirmware(Firmware):
         bin_file: Optional[str] = None,
         dat_file: Optional[str] = None,
         info_read_only_metadata: Optional[dict[str, Any]] = None,
-    ):
+    ) -> None:
         """
         The SoftdeviceBootloaderFirmware data model
 
@@ -120,7 +120,7 @@ class Manifest:
         bootloader: Optional[dict[str, Any]] = None,
         softdevice: Optional[dict[str, Any]] = None,
         softdevice_bootloader: Optional[dict[str, Any]] = None,
-    ):
+    ) -> None:
         """
         The Manifest data model.
 


### PR DESCRIPTION
The [flake8-annotations (ANN*) checks](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) ensure that our code has type annotations. This is currently also checked by mypy, but ty does not enforce this. Enabling these checks thus prepares a potential migration to ty and in any case speeds up the checks.

The ANN401 check forbids annotations with typing.Any. As we use Any in some cases where we don’t care about the type, this check is currently disabled.

