### PR TITLE
Make TrussedBase implement AbstractContextManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `nitrokey.trussed.list`: add optional `use_ccid` argument
   - `nitrokey.list`: add `should_default_ccid` function, that indicates when CCID should be prefered. CCID is more limited than CTAPHID, so this functions only returns `True` on Windows when not an administrator, as CTAPHID is not available in this case.
 - Remove support for `fido2` v1.
+- `nitrokey.trussed.TrussedBase`: Fix type annotations for `__exit__` arguments so that all derived classes implement the `contextlib.AbstractContextManager` protocol.
 
 ## [v0.4.2](https://github.com/Nitrokey/nitrokey-sdk-py/releases/tag/v0.4.2) (2025-11-26)
 

--- a/src/nitrokey/nk3/_bootloader.py
+++ b/src/nitrokey/nk3/_bootloader.py
@@ -5,7 +5,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from nitrokey import _VID_NITROKEY
 from nitrokey.trussed._base import Model
@@ -85,3 +85,10 @@ class NK3BootloaderNrf52(TrussedBootloaderNrf52, NK3Bootloader):
         from . import _NK3_DATA
 
         return _NK3_DATA.nrf52_signature_keys
+
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    _ACM_NRF52: type[AbstractContextManager[NK3BootloaderNrf52]] = NK3BootloaderNrf52
+    _ACM_LPC55: type[AbstractContextManager[NK3BootloaderLpc55]] = NK3BootloaderLpc55

--- a/src/nitrokey/nk3/_device.py
+++ b/src/nitrokey/nk3/_device.py
@@ -5,7 +5,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from fido2.hid import CtapHidDevice
 
@@ -70,3 +70,9 @@ class NK3(TrussedDevice):
         return cls._list_pcsc_atr(
             list(bytes.fromhex("3B8F01805D4E6974726F6B657900000000006A")), exclusive
         )
+
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    _: type[AbstractContextManager[NK3]] = NK3

--- a/src/nitrokey/nkpk.py
+++ b/src/nitrokey/nkpk.py
@@ -6,7 +6,7 @@
 # copied, modified, or distributed except according to those terms.
 
 import builtins
-from typing import List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 from fido2.hid import CtapHidDevice
 
@@ -128,3 +128,10 @@ def open(path: str) -> Optional[Union[NKPK, NKPKBootloader]]:
     if bootloader_device:
         return bootloader_device
     return None
+
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    _ACM_DEV: type[AbstractContextManager[NKPK]] = NKPK
+    _ACM_BL: type[AbstractContextManager[NKPKBootloader]] = NKPKBootloader

--- a/src/nitrokey/trussed/_base.py
+++ b/src/nitrokey/trussed/_base.py
@@ -7,6 +7,7 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
+from types import TracebackType
 from typing import Optional, TypeVar
 
 from nitrokey import _VID_NITROKEY
@@ -40,7 +41,12 @@ class TrussedBase(ABC):
     def __enter__(self: T) -> T:
         return self
 
-    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         self.close()
 
     def _validate_vid_pid(self, vid: int, pid: int) -> None:


### PR DESCRIPTION
This patch fixes the type annotations for the arguments of the `TrussedBase.__exit__` function so that all classes deriving from it implement the `contextlib.AbstractContextManager` protocol. It also adds assertions that verify this while type checking.