### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         run: poetry build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nitrokey-pypi
           path: dist

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nitrokey-pypi
           path: dist
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nitrokey-pypi
           path: dist

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -18,7 +18,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
       - name: Check package version format
@@ -34,7 +34,7 @@ jobs:
     needs: check-package-version
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
       - name: Build
@@ -56,7 +56,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -74,7 +74,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Poetry
         run: pip install "${POETRY_SPEC}"
       - name: Check tag version
@@ -97,7 +97,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -31,7 +31,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -46,7 +46,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -61,7 +61,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -76,7 +76,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -91,7 +91,7 @@ jobs:
     container: fedora:42
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: dnf makecache && dnf install -y make rpm-build python python-pip python3-devel gcc systemd-devel
       - name: Install Poetry
@@ -110,7 +110,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -125,7 +125,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -140,7 +140,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES}
       - name: Install Poetry
@@ -159,7 +159,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -174,7 +174,7 @@ jobs:
     container: python:3.10-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES} cargo
       - name: Install tangler
@@ -201,7 +201,7 @@ jobs:
       UV_RESOLUTION: ${{ matrix.resolution }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required packages
         run: apt update && apt install -y ${REQUIRED_PACKAGES} gcc libffi-dev
       - name: Install uv

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This PR update the following actions used in the CI/CD pipelines.

- `actions/checkout` from `v4` to `v6`
- `actions/upload-artifact` from `v4` to `v6`
- `actions/download-artifact` from `v4` to `v8`

Some Actions now require more recent versions of the GitHub Runner software. I checked with our self-hosted runner and the new requirements are already fulfilled. Besides, I didn't see any other changes which are noteworthy for us.