### PR TITLE
Update GitHub action setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install SDK

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install SDK


### PR DESCRIPTION
This PR updates the GitHub action `actions/setup-python` from `v5` to `v6`.