### PR TITLE
Add support for protobuf v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove RPM specification file, associated Makefile target, and CI jobs.
+- Add support for `protobuf` v7.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.5.0-rc.1...HEAD)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2041,4 +2041,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "2ff6f6615b45067173aee3fdd7cc6f4409e696f0f290be36f1e55bf2141686b3"
+content-hash = "3547ec3573195d476cfd819ee2b9aaee0ccce6f3a400278b4dd7c166720dfc5f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "hidapi >=0.14, <0.15",
 
     # nrf52
-    "protobuf >=5.26, <7",
+    "protobuf >=5.26, <8",
     "pyserial >=3.5, <4",
 ]
 
@@ -54,7 +54,7 @@ rstcheck = { version = "^6", extras = ["sphinx"] }
 ruff = "^0.14"
 sphinx = "^7"
 ty = "^0.0.29"
-types-protobuf = ">=5.26, <7"
+types-protobuf = ">=5.26, <8"
 types-requests = "^2.16"
 typing-extensions = "^4.1"
 # fake-winreg does not work with wrapt v2 so we need to add an additional upper bound
@@ -66,7 +66,7 @@ dev-dependencies = [
     "fake-winreg >=1.9, <2",
     "mypy >=1.20, <2",
     "ty >=0.0.29, <0.0.30",
-    "types-protobuf >=5.26, <7",
+    "types-protobuf >=5.26, <8",
     "types-requests >=2.16, <3",
 
     # These additional lower bounds are required for --resolution lowest.


### PR DESCRIPTION
Fixes: https://github.com/Nitrokey/nitrokey-sdk-py/issues/119