### PR TITLE
Add minimum dependency age

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 env:
   REQUIRED_PACKAGES: make
   POETRY_SPEC: poetry >=2, <2.3
+  UV_EXCLUDE_NEWER: 0 days
+  PIP_UPLOADED_PRIOR_TO: P0D
 
 jobs:
   format-code:

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P0D
+
 jobs:
   test-pip:
     name: Run test suite with pip installation

--- a/.pip/pip.conf
+++ b/.pip/pip.conf
@@ -1,0 +1,3 @@
+[global]
+uploaded-prior-to = P7D
+

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,4 @@
+[solver]
+min-release-age = 7
+min-release-age-exclude = ["nitrokey"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ dev-dependencies = [
     # fake-winreg does not work with wrapt v2 so we need to add an additional upper bound
     "wrapt <2",
 ]
+exclude-newer = "7 days"
+# Can be used to update packages to a version more recent what exclude-newer allows
+exclude-newer-package = { }
 
 [tool.mypy]
 mypy_path = "stubs"


### PR DESCRIPTION
This adds a configuration so that poetry, uv and pip don't consider releases that are less than 7 days old to reduce the risk of installing malware through simple dependency update.

While we don't have a lockfile here, this still protects developpers against machine takeovers