### PR TITLE
Pin cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- `nitrokey.nk3.secrets_app`: Fix discarded authentication when using `SecretsApp` over CCID
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.5.0-rc.2...HEAD)
 

--- a/src/nitrokey/nk3/secrets_app.py
+++ b/src/nitrokey/nk3/secrets_app.py
@@ -9,6 +9,7 @@ import dataclasses
 import hmac
 import logging
 import typing
+from datetime import datetime
 from enum import Enum, IntEnum
 from hashlib import pbkdf2_hmac
 from secrets import token_bytes
@@ -779,6 +780,7 @@ class SecretsApp:
     def verify_pin_raw(self, password: str) -> None:
         structure = [tlv8.Entry(Tag.Password.value, password)]
         self._send_receive(Instruction.VerifyPIN, structure=structure)
+        self.dev._secrets_pin_cache = datetime.now()
 
     def get_feature_status_cached(self) -> SelectResponse:
         self._cache_status = self.select() if self._cache_status is None else self._cache_status

--- a/src/nitrokey/trussed/_device.py
+++ b/src/nitrokey/trussed/_device.py
@@ -10,6 +10,7 @@ import logging
 import platform
 import sys
 from abc import abstractmethod
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import List, Optional, Sequence, TypeVar, Union
 
@@ -68,6 +69,7 @@ class TrussedDevice(TrussedBase):
 
         self.device = device
         self.fido2_certs = fido2_certs
+        self._secrets_pin_cache: datetime | None = None
 
         from .admin_app import AdminApp
 
@@ -150,17 +152,25 @@ class TrussedDevice(TrussedBase):
 
     def _call_ccid(self, app: App, response_len: Optional[int] = None, data: bytes = b"") -> bytes:
         assert not isinstance(self.device, CtapHidDevice)
-        select = bytes([0x00, 0xA4, 0x04, 0x00, len(app.aid())]) + app.aid()
-        tmpbytes, sw1, sw2 = self.device.transmit(list(select))
-        while True:
-            if sw1 == 0x61:
-                _, sw1, sw2 = self.device.transmit(
-                    list(Iso7816Apdu(0x00, 0xC0, 0, 0, None, sw2).to_bytes())
-                )
-                continue
-            break
-        if sw1 != 0x90 or sw2 != 0x00:
-            raise PcscError(sw1, sw2)
+        # SELECT resets the PIN verification status of secrets-app, so we skip the next select
+        # within 100 ms of a PIN verification
+        skip_perform_select = (
+            self._secrets_pin_cache
+            and (datetime.now() - self._secrets_pin_cache) < timedelta(milliseconds=100)
+            and app == App.SECRETS
+        )
+        if not skip_perform_select:
+            select = bytes([0x00, 0xA4, 0x04, 0x00, len(app.aid())]) + app.aid()
+            tmpbytes, sw1, sw2 = self.device.transmit(list(select))
+            while True:
+                if sw1 == 0x61:
+                    _, sw1, sw2 = self.device.transmit(
+                        list(Iso7816Apdu(0x00, 0xC0, 0, 0, None, sw2).to_bytes())
+                    )
+                    continue
+                break
+            if sw1 != 0x90 or sw2 != 0x00:
+                raise PcscError(sw1, sw2)
 
         command = None
         if app == App.ADMIN or app == App.PROVISIONER:
@@ -179,6 +189,7 @@ class TrussedDevice(TrussedBase):
                 continue
             break
 
+        self._secrets_pin_cache = None  # Running any command removes the pin auth cache
         if app == App.SECRETS:
             accumulator = bytes([sw1, sw2]) + accumulator
             # Let the secret app handle the error


### PR DESCRIPTION
Changes

- Cache pin auth state for 100ms
- Skip SELECT command over CCID for SECRETS app if device is in authenticated state
- Fixes usability of pin protected passwords over CCID path

Handles https://github.com/Nitrokey/nitrokey-app2/issues/419