### PR TITLE
Update to Python 3.11

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -15,7 +15,7 @@ jobs:
   check-package-version:
     name: Check package version
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     needs: check-package-version
     steps:
       - name: Checkout repository
@@ -70,7 +70,7 @@ jobs:
   check-tag-version:
     name: Check tag version
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     if: github.event_name == 'release'
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
   format-code:
     name: Check code format
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -31,7 +31,7 @@ jobs:
   lint-style:
     name: Check code style
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -46,7 +46,7 @@ jobs:
   lint-typing:
     name: Check static typing
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -61,7 +61,7 @@ jobs:
   lint-poetry:
     name: Check poetry configuration
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -76,7 +76,7 @@ jobs:
   lint-docs:
     name: Check documentation
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -91,7 +91,7 @@ jobs:
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -106,7 +106,7 @@ jobs:
   test:
     name: Run test suite
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -121,7 +121,7 @@ jobs:
   test-update:
     name: Run test suite with updated dependencies
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -147,7 +147,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install SDK
         run: pip install .
       - name: Run test suite
@@ -155,7 +155,7 @@ jobs:
   test-readme:
     name: Run example code from readme
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -174,7 +174,7 @@ jobs:
   test-uv-resolution:
     name: Test different resolution strategies with uv
     runs-on: ubuntu-latest
-    container: python:3.10-slim
+    container: python:3.11-slim
     strategy:
       matrix:
         resolution:

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -14,7 +14,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          # hidapi does not build on Windows and does not have wheels for Python 3.14
+          - os: windows-latest
+            python-version: "3.14"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -23,6 +27,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      # hidapi needs to be built from source for Python 3.14
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev libusb-1.0-0-dev
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
       - name: Install SDK
         run: pip install .
       - name: Run test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `nitrokey.nk3.secrets_app`: Fix discarded authentication when using `SecretsApp` over CCID
+- Bump minimum Python version to 3.11.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.5.0-rc.2...HEAD)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for device in nitrokey.trussed.list():
 
 ## Compatibility
 
-The Nitrokey Python SDK currently requires Python 3.10 or later.
+The Nitrokey Python SDK currently requires Python 3.11 or later.
 Support for old Python versions may be dropped in minor releases.
 
 ## Related Projects
@@ -61,7 +61,7 @@ Support for old Python versions may be dropped in minor releases.
 
 The following software is required for the development of the SDK:
 
-- Python 3.10 or newer
+- Python 3.11 or newer
 - [poetry](https://python-poetry.org/)
 - GNU Make
 - git

--- a/poetry.lock
+++ b/poetry.lock
@@ -400,7 +400,6 @@ files = [
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
-typing-extensions = {version = ">=4.13.2", markers = "python_full_version < \"3.11.0\""}
 
 [package.extras]
 ssh = ["bcrypt (>=3.1.5)"]
@@ -967,7 +966,6 @@ files = [
 librt = {version = ">=0.8.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
 pathspec = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing_extensions = [
     {version = ">=4.6.0", markers = "python_version < \"3.15\""},
     {version = ">=4.14.0", markers = "python_version >= \"3.15\""},
@@ -1429,7 +1427,6 @@ files = [
 click = ">=8"
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=12"
-typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["inline-snapshot (>=0.24)", "jsonschema (>=4)", "mypy (>=1.14.1)", "nodeenv (>=1.9.1)", "packaging (>=25)", "pre-commit (>=3.5)", "pytest (>=8.3.5)", "pytest-cov (>=5)", "rich-codex (>=1.2.11)", "ruff (>=0.12.4)", "typer (>=0.15,<0.26)", "types-setuptools (>=75.8.0.20250110)"]
@@ -1675,7 +1672,6 @@ sphinxcontrib-htmlhelp = ">=2.0.0"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = ">=1.1.9"
-tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
@@ -1794,64 +1790,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.4.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
-    {file = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"},
-    {file = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"},
-    {file = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"},
-    {file = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"},
-    {file = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"},
-    {file = "tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"},
-    {file = "tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"},
-    {file = "tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece"},
-    {file = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"},
-    {file = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"},
-    {file = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"},
-    {file = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"},
-    {file = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"},
-    {file = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"},
-    {file = "tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917"},
-    {file = "tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"},
-    {file = "tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257"},
-    {file = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"},
-    {file = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"},
-    {file = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"},
-    {file = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"},
-    {file = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"},
-    {file = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"},
-    {file = "tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd"},
-    {file = "tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"},
-    {file = "tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd"},
-    {file = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"},
-    {file = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"},
-    {file = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"},
-    {file = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"},
-    {file = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"},
-    {file = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"},
-    {file = "tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6"},
-    {file = "tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"},
-    {file = "tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232"},
-    {file = "tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4"},
-    {file = "tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c"},
-    {file = "tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d"},
-    {file = "tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41"},
-    {file = "tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c"},
-    {file = "tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f"},
-    {file = "tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8"},
-    {file = "tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26"},
-    {file = "tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396"},
-    {file = "tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"},
-    {file = "tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"},
-]
-
-[[package]]
 name = "ty"
 version = "0.0.29"
 description = "An extremely fast Python type checker, written in Rust."
@@ -1929,12 +1867,11 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version == \"3.10\""}
 
 [[package]]
 name = "typing-inspection"
@@ -2065,5 +2002,5 @@ pcsc = ["pyscard"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10, <4"
-content-hash = "2ff6f6615b45067173aee3fdd7cc6f4409e696f0f290be36f1e55bf2141686b3"
+python-versions = ">=3.11, <4"
+content-hash = "28398d6f429a6342a85c42a514ca65f178750dd6c4f5f5a6c2f63b05205e7546"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2003,4 +2003,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <4"
-content-hash = "28398d6f429a6342a85c42a514ca65f178750dd6c4f5f5a6c2f63b05205e7546"
+content-hash = "f403f68b2aaaa00b37c57654d8d73210d07d3ffe86fa1ca886b107ca41e388ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 packages = [
     { include = "nitrokey", from = "src" },
 ]
-requires-python = ">=3.10, <4"
+requires-python = ">=3.11, <4"
 dynamic = ["classifiers"]
 
 dependencies = [
@@ -85,7 +85,7 @@ exclude-newer-package = { }
 [tool.mypy]
 mypy_path = "stubs"
 show_error_codes = true
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 
 [tool.rstcheck]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ sphinx = "^7"
 ty = "^0.0.29"
 types-protobuf = ">=5.26, <7"
 types-requests = "^2.16"
-typing-extensions = "^4.1"
 # fake-winreg does not work with wrapt v2 so we need to add an additional upper bound
 wrapt = "<2"
 

--- a/src/nitrokey/trussed/_bootloader/__init__.py
+++ b/src/nitrokey/trussed/_bootloader/__init__.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import sys
+import typing
 from abc import abstractmethod
 from dataclasses import dataclass
 from io import BytesIO
@@ -45,7 +46,8 @@ def get_model_data(model: Model) -> ModelData:
         from nitrokey.nkpk import _NKPK_DATA
 
         return _NKPK_DATA
-    raise ValueError(f"Unknown model {model}")
+
+    typing.assert_never(model)
 
 
 class Variant(enum.Enum):
@@ -132,7 +134,7 @@ def get_firmware_filename_pattern(variant: Variant) -> Pattern[str]:
     elif variant == Variant.NRF52:
         return FILENAME_PATTERN_NRF52
     else:
-        raise ValueError(f"Unexpected variant {variant}")
+        typing.assert_never(variant)
 
 
 def parse_filename(filename: str) -> Optional[Tuple[Variant, Version]]:

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/commands.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/commands.py
@@ -10,7 +10,7 @@
 import math
 from abc import abstractmethod
 from struct import calcsize, pack, unpack_from
-from typing import TYPE_CHECKING, Mapping, Optional, Type
+from typing import Mapping, Optional, Self, Type
 
 from crcmod.predefined import mkPredefinedCrcFun
 
@@ -20,9 +20,6 @@ from ...sbfile.misc import SecBootBlckSize
 from ...utils.abstract import BaseClass
 from ...utils.misc import Endianness
 from ...utils.spsdk_enum import SpsdkEnum
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 ########################################################################################################################
 # Constants
@@ -116,7 +113,7 @@ class CmdHeader(BaseClass):
         return pack(self.FORMAT, crc, self.tag, self.flags, self.address, self.count, self.data)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command header from bytes.
 
         :param data: Input data as bytes
@@ -171,7 +168,7 @@ class CmdBaseClass(BaseClass):
 
     @classmethod
     @abstractmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Deserialize object from bytes array."""
 
 
@@ -183,7 +180,7 @@ class CmdNop(CmdBaseClass):
         super().__init__(EnumCmdTag.NOP)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -207,7 +204,7 @@ class CmdTag(CmdBaseClass):
         super().__init__(EnumCmdTag.TAG)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -294,7 +291,7 @@ class CmdLoad(CmdBaseClass):
         self._header.data = crc32_function(self.data, 0xFFFFFFFF)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -392,7 +389,7 @@ class CmdFill(CmdBaseClass):
         )
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -462,7 +459,7 @@ class CmdJump(CmdBaseClass):
         return nfo
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -514,7 +511,7 @@ class CmdCall(CmdBaseClass):
         return f"CALL: Address=0x{self.address:08X}, Argument=0x{self.argument:08X}"
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -588,7 +585,7 @@ class CmdErase(CmdBaseClass):
         )
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -612,7 +609,7 @@ class CmdReset(CmdBaseClass):
         super().__init__(EnumCmdTag.RESET)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -688,7 +685,7 @@ class CmdMemEnable(CmdBaseClass):
         )
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -797,7 +794,7 @@ class CmdProg(CmdBaseClass):
         )
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -855,7 +852,7 @@ class CmdVersionCheck(CmdBaseClass):
         )
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes
@@ -919,7 +916,7 @@ class CmdKeyStoreBackupRestore(CmdBaseClass):
         return (self.header.flags & self.ROM_MEM_DEVICE_ID_MASK) >> self.ROM_MEM_DEVICE_ID_SHIFT
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Parse command from bytes.
 
         :param data: Input data as bytes

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/headers.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/sbfile/sb2/headers.py
@@ -9,15 +9,12 @@
 
 from datetime import datetime
 from struct import calcsize, unpack_from
-from typing import TYPE_CHECKING, Optional
+from typing import Optional, Self
 
 from ...exceptions import SPSDKError
 from ...sbfile.misc import BcdVersion3, unpack_timestamp
 from ...utils.abstract import BaseClass
 from ...utils.misc import swap16
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 
 ########################################################################################################################
@@ -102,7 +99,7 @@ class ImageHeaderV2(BaseClass):
 
     # pylint: disable=too-many-locals
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Deserialization from binary form.
 
         :param data: binary representation

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/crypto/cert_blocks.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/crypto/cert_blocks.py
@@ -9,16 +9,13 @@
 
 import re
 from struct import calcsize, unpack_from
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Optional, Self, Union
 
 from ...crypto.certificate import Certificate
 from ...exceptions import SPSDKError
 from ...utils.abstract import BaseClass
 from ...utils.crypto.rkht import RKHTv1
 from ...utils.misc import Endianness, align
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 
 class CertBlock(BaseClass):
@@ -74,7 +71,7 @@ class CertBlockHeader(BaseClass):
         return nfo
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Deserialize object from bytes array.
 
         :param data: Input data as bytes
@@ -294,7 +291,7 @@ class CertBlockV1(CertBlock):
         return pub_key.verify_signature(signature=signature, data=data)
 
     @classmethod
-    def parse(cls, data: bytes) -> "Self":
+    def parse(cls, data: bytes) -> Self:
         """Deserialize CertBlockV1 from binary file.
 
         :param data: Binary data

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/crypto/rkht.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/crypto/rkht.py
@@ -8,13 +8,10 @@
 """The module provides support for Root Key Hash table."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List
+from typing import List, Self
 
 from ...crypto.hash import EnumHashAlgorithm, get_hash
 from ...exceptions import SPSDKError
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 
 class RKHT:
@@ -85,7 +82,7 @@ class RKHTv1(RKHT):
         return rotk_table
 
     @classmethod
-    def parse(cls, rkht: bytes) -> "Self":
+    def parse(cls, rkht: bytes) -> Self:
         """Parse Root Key Hash Table into RKHTv1 object.
 
         :param rkht: Valid RKHT table

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/interfaces/device/base.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/interfaces/device/base.py
@@ -9,16 +9,13 @@
 
 from abc import ABC, abstractmethod
 from types import TracebackType
-from typing import TYPE_CHECKING, Optional, Type
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
+from typing import Optional, Self, Type
 
 
 class DeviceBase(ABC):
     """Device base class."""
 
-    def __enter__(self) -> "Self":
+    def __enter__(self) -> Self:
         self.open()
         return self
 

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/interfaces/protocol/protocol_base.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/interfaces/protocol/protocol_base.py
@@ -9,13 +9,10 @@
 
 from abc import ABC, abstractmethod
 from types import TracebackType
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import Optional, Self, Type, Union
 
 from ....utils.interfaces.commands import CmdPacketBase, CmdResponseBase
 from ....utils.interfaces.device.base import DeviceBase
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 
 class ProtocolBase(ABC):
@@ -34,7 +31,7 @@ class ProtocolBase(ABC):
     def __str__(self) -> str:
         return f"identifier='{self.identifier}', device={self.device}"
 
-    def __enter__(self) -> "Self":
+    def __enter__(self) -> Self:
         self.open()
         return self
 

--- a/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/spsdk_enum.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55_upload/utils/spsdk_enum.py
@@ -9,10 +9,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional, Union
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
+from typing import List, Optional, Self, Union
 
 from ..exceptions import SPSDKKeyError, SPSDKTypeError
 
@@ -98,7 +95,7 @@ class SpsdkEnum(SpsdkEnumMember, Enum):
         return value.description or default
 
     @classmethod
-    def from_attr(cls, attribute: Union[int, str]) -> "Self":
+    def from_attr(cls, attribute: Union[int, str]) -> Self:
         """Get enum member with given tag/label attribute.
 
         :param attribute: Attribute value of enum member
@@ -111,7 +108,7 @@ class SpsdkEnum(SpsdkEnumMember, Enum):
             return cls.from_label(attribute)
 
     @classmethod
-    def from_tag(cls, tag: int) -> "Self":
+    def from_tag(cls, tag: int) -> Self:
         """Get enum member with given tag.
 
         :param tag: Tag to be used for searching
@@ -124,7 +121,7 @@ class SpsdkEnum(SpsdkEnumMember, Enum):
         raise SPSDKKeyError(f"There is no {cls.__name__} item in with tag {tag} defined")
 
     @classmethod
-    def from_label(cls, label: str) -> "Self":
+    def from_label(cls, label: str) -> Self:
         """Get enum member with given label.
 
         :param label: Label to be used for searching

--- a/src/nitrokey/trussed/_device.py
+++ b/src/nitrokey/trussed/_device.py
@@ -9,6 +9,7 @@ import enum
 import logging
 import platform
 import sys
+import typing
 from abc import abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum
@@ -49,8 +50,7 @@ class App(Enum):
         elif self == App.PROVISIONER:
             return bytes.fromhex("A00000084700000001")
         else:
-            # TODO: use typing.assert_never
-            raise ValueError(self)
+            typing.assert_never(self)
 
 
 class TrussedDevice(TrussedBase):

--- a/src/nitrokey/trussed/admin_app.py
+++ b/src/nitrokey/trussed/admin_app.py
@@ -1,4 +1,5 @@
 import enum
+import typing
 from dataclasses import dataclass
 from enum import Enum, IntFlag
 from typing import Optional
@@ -187,8 +188,7 @@ class ConfigFieldType(Enum):
             except ValueError:
                 return False
         else:
-            # TODO: use typing.assert_never from Python 3.11
-            raise ValueError(self)
+            typing.assert_never(self)
 
     def __str__(self) -> str:
         if self == ConfigFieldType.BOOL:
@@ -196,8 +196,7 @@ class ConfigFieldType(Enum):
         elif self == ConfigFieldType.U8:
             return "u8"
         else:
-            # TODO: use typing.assert_never from Python 3.11
-            raise ValueError(self)
+            typing.assert_never(self)
 
 
 @dataclass

--- a/src/nitrokey/trussed/updates.py
+++ b/src/nitrokey/trussed/updates.py
@@ -11,12 +11,13 @@ import logging
 import platform
 import re
 import time
+import typing
 from abc import ABC, abstractmethod
 from collections.abc import Set
 from contextlib import contextmanager
 from importlib.metadata import PackageNotFoundError
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
 
 from nitrokey._helpers import Retries
 from nitrokey.trussed import TimeoutException, TrussedBase, Version
@@ -33,9 +34,6 @@ from nitrokey.trussed._device import TrussedDevice
 from nitrokey.trussed.admin_app import BootMode, Status
 from nitrokey.trussed.admin_app import Variant as AdminAppVariant
 from nitrokey.updates import Asset, Release, Repository
-
-if TYPE_CHECKING:
-    import typing_extensions
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +77,7 @@ class Warning(enum.Enum):
                 " https://github.com/Nitrokey/nitrokey-3-firmware/releases"
             )
 
-        if TYPE_CHECKING:
-            typing_extensions.assert_never(self)
-
-        return self.value
+        typing.assert_never(self)
 
     @classmethod
     def from_str(cls, s: str) -> "Warning":
@@ -118,10 +113,7 @@ class _Migration(enum.Enum):
             elif variant == AdminAppVariant.NRF52:
                 variant = Variant.NRF52
             else:
-                if TYPE_CHECKING:
-                    typing_extensions.assert_never(variant)
-
-                raise ValueError(f"Unsupported device variant: {variant}")
+                typing.assert_never(variant)
 
         migrations = set()
 


### PR DESCRIPTION
Python 3.10 will be EOL in October. All relevant distributions ship at least Python 3.11. Updating to Python 3.11 allows us to use new features like `typing.assert_never`.