### PR TITLE
inner_checksum added to firmware metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `nitrokey.nk3.secrets_app`: Fix discarded authentication when using `SecretsApp` over CCID
 - Bump minimum Python version to 3.11.
+- `nitrokey.trussed`: Add the `inner_checksum` field to `FirmwareMetadata` with the checksum of the unsigned firmware image.
 
 [All Changes](https://github.com/Nitrokey/nitrokey-sdk-py/compare/v0.5.0-rc.2...HEAD)
 

--- a/src/nitrokey/trussed/_bootloader/__init__.py
+++ b/src/nitrokey/trussed/_bootloader/__init__.py
@@ -114,6 +114,7 @@ class FirmwareMetadata:
     version: Version
     signed_by: Optional[str] = None
     signed_by_nitrokey: bool = False
+    inner_checksum: bytes | None = None
 
 
 class TrussedBootloader(TrussedBase):

--- a/src/nitrokey/trussed/_bootloader/lpc55.py
+++ b/src/nitrokey/trussed/_bootloader/lpc55.py
@@ -5,6 +5,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import hashlib
 import logging
 import platform
 import re
@@ -17,6 +18,7 @@ from . import FirmwareMetadata, ProgressCallback, TrussedBootloader, Variant
 from .lpc55_upload.mboot.interfaces.usb import MbootUSBInterface
 from .lpc55_upload.mboot.mcuboot import McuBoot
 from .lpc55_upload.mboot.properties import PropertyTag
+from .lpc55_upload.sbfile.sb2.commands import CmdLoad
 from .lpc55_upload.sbfile.sb2.images import BootImageV21
 from .lpc55_upload.utils.interfaces.device.usb_device import UsbDevice
 
@@ -122,6 +124,40 @@ class TrussedBootloaderLpc55(TrussedBootloader):
             return None
 
 
+def _inner_checksum(image: BootImageV21) -> bytes:
+    """
+    Calculates the checksum of the raw (unsigned) image from a SB2 file containing a Master Boot
+    Image (MBI). We assume that there is only a single Load command containing the full image and
+    that it is an MBI type 4 image. To produce the unsigned image from the MBI, we have to clear
+    the MBI header (placed in the vector table) and cut off the certificate block (at the location
+    indicated in the MBI header).
+
+    See: https://spsdk.readthedocs.io/en/latest/examples/_knowledge_base/mbi_summary.html
+    """
+    MBI_PATCH_START = 0x20
+    MBI_PATCH_LEN = 0xB
+
+    loads = [cmd for section in image.boot_sections for cmd in section if isinstance(cmd, CmdLoad)]
+    assert len(loads) == 1
+    mbi = memoryview(loads[0].data)
+
+    assert len(mbi) > MBI_PATCH_START + MBI_PATCH_LEN
+    assert mbi[0x24] == 0x04  # SPT-Xip
+    offset_loc = 0x28
+    header_size = 4
+    marker = int.from_bytes(mbi[offset_loc:][:header_size], "little")
+
+    # cut off certificate block
+    raw_image = mbi[:marker]
+
+    h = hashlib.sha256()
+    h.update(raw_image[:MBI_PATCH_START])
+    # zero out MBI header
+    h.update(b"\x00" * MBI_PATCH_LEN)
+    h.update(raw_image[MBI_PATCH_START:][MBI_PATCH_LEN:])
+    return h.digest()
+
+
 def parse_firmware_image(data: bytes) -> FirmwareMetadata:
     image = BootImageV21.parse(data, kek=KEK)
     bcd_version = image.header.product_version
@@ -133,4 +169,5 @@ def parse_firmware_image(data: bytes) -> FirmwareMetadata:
             metadata.signed_by_nitrokey = True
         else:
             metadata.signed_by = f"unknown issuer (RKTH: {image.cert_block.rkth.hex()})"
+    metadata.inner_checksum = _inner_checksum(image)
     return metadata

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,16 +1,28 @@
 import unittest
+from typing import Optional
 
 from nitrokey.trussed import FirmwareContainer, Model, Variant, parse_firmware_image
 
 
 class TestFirmwareContainer(unittest.TestCase):
     def test_parse_nk3(self) -> None:
-        self._test(Model.NK3, "v1.7.2", [Variant.LPC55, Variant.NRF52])
+        self._test(
+            Model.NK3,
+            "v1.7.2",
+            [Variant.LPC55, Variant.NRF52],
+            {Variant.LPC55: "51b76ef121d3e44270a65d8fe09165b133ecbdf85601e5dfb9d1cab19a988758"},
+        )
 
     def test_parse_nkpk(self) -> None:
         self._test(Model.NKPK, "v1.0.0", [Variant.NRF52])
 
-    def _test(self, model: Model, version: str, variants: list[Variant]) -> None:
+    def _test(
+        self,
+        model: Model,
+        version: str,
+        variants: list[Variant],
+        checksum: Optional[dict[Variant, str]] = None,
+    ) -> None:
         path = f"./tests/data/firmware-{model.name.lower()}-{version}.zip"
         container = FirmwareContainer.parse(path, model)
         self.assertEqual(str(container.version), version)
@@ -22,3 +34,8 @@ class TestFirmwareContainer(unittest.TestCase):
             self.assertEqual(str(metadata.version), version)
             self.assertEqual(metadata.signed_by, "Nitrokey")
             self.assertTrue(metadata.signed_by_nitrokey)
+            if checksum and variant in checksum:
+                self.assertEqual(
+                    metadata.inner_checksum.hex() if metadata.inner_checksum else "",
+                    checksum[variant],
+                )


### PR DESCRIPTION
Inner checksum implemented which reads the sb2 file, tries to extract the corresponding bin file and calculate a checksum